### PR TITLE
コメント_API作成 

### DIFF
--- a/src/_types/comment.ts
+++ b/src/_types/comment.ts
@@ -1,0 +1,3 @@
+export interface Comment{
+  comment: string
+}

--- a/src/app/api/diaries/[id]/comments/[commentId]/route.ts
+++ b/src/app/api/diaries/[id]/comments/[commentId]/route.ts
@@ -3,6 +3,7 @@ import { userAuthentication } from "@/app/utils/userAuthentication";
 import { verifyUser } from "@/app/utils/verifyUser";
 import { PrismaClient } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
+import { Comment } from "@/_types/comment";
 
 const prisma = new PrismaClient();
 
@@ -38,7 +39,7 @@ export const PUT = async(request: NextRequest, {params}: { params: { commentId: 
   await verifyUser(currentUserId, commentId, prisma.comment)
 
   const body = await request.json();
-  const { comment } = body;
+  const { comment }: Comment = body;
 
   try {
     const updatedComment = await prisma.comment.update({

--- a/src/app/api/diaries/[id]/comments/[commentId]/route.ts
+++ b/src/app/api/diaries/[id]/comments/[commentId]/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 const prisma = new PrismaClient();
 
 // コメント削除
-export const DELETE = async(request: NextRequest, { params } : { params: { id: string, commentId: string }} ) => {
+export const DELETE = async(request: NextRequest, { params } : { params: { commentId: string }} ) => {
   const { commentId } = params
   const { data, error } = await userAuthentication(request);
   if (error) return handleError(request)
@@ -29,13 +29,13 @@ export const DELETE = async(request: NextRequest, { params } : { params: { id: s
 }
 
 // コメント編集
-export const PUT = async(request: NextRequest, {params}: { params: { id: string }} ) => {
-  const { id } = params
+export const PUT = async(request: NextRequest, {params}: { params: { commentId: string }} ) => {
+  const { commentId } = params
   const { data, error } = await userAuthentication(request);
   if (error) return handleError(request);
   
   const currentUserId = data.user.id;
-  await verifyUser(currentUserId, id, prisma.comment)
+  await verifyUser(currentUserId, commentId, prisma.comment)
 
   const body = await request.json();
   const { comment } = body;
@@ -43,7 +43,7 @@ export const PUT = async(request: NextRequest, {params}: { params: { id: string 
   try {
     const updatedComment = await prisma.comment.update({
       where: {
-        id,
+        id: commentId,
       },
       data: {
         comment,

--- a/src/app/api/diaries/[id]/comments/[commentId]/route.ts
+++ b/src/app/api/diaries/[id]/comments/[commentId]/route.ts
@@ -1,0 +1,29 @@
+import { handleError } from "@/app/utils/errorHandler";
+import { userAuthentication } from "@/app/utils/userAuthentication";
+import { verifyUser } from "@/app/utils/verifyUser";
+import { PrismaClient } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+
+const prisma = new PrismaClient();
+
+// コメント削除
+export const DELETE = async(request: NextRequest, { params } : { params: { id: string, commentId: string }} ) => {
+  const { commentId } = params
+  const { data, error } = await userAuthentication(request);
+  if (error) return handleError(request)
+
+  const currentUserId = data.user.id;
+  await verifyUser(currentUserId, commentId, prisma.comment)
+
+  try {
+    const deletedComment = await prisma.comment.delete({
+      where: {
+        id: commentId
+      },
+    });
+
+    return NextResponse.json({ status: "OK", message: "コメント削除しました", comment: deletedComment}, { status: 200});
+  } catch(error) {
+    return handleError(error);
+  }
+}

--- a/src/app/api/diaries/[id]/comments/[commentId]/route.ts
+++ b/src/app/api/diaries/[id]/comments/[commentId]/route.ts
@@ -27,3 +27,31 @@ export const DELETE = async(request: NextRequest, { params } : { params: { id: s
     return handleError(error);
   }
 }
+
+// コメント編集
+export const PUT = async(request: NextRequest, {params}: { params: { id: string }} ) => {
+  const { id } = params
+  const { data, error } = await userAuthentication(request);
+  if (error) return handleError(request);
+  
+  const currentUserId = data.user.id;
+  await verifyUser(currentUserId, id, prisma.comment)
+
+  const body = await request.json();
+  const { comment } = body;
+
+  try {
+    const updatedComment = await prisma.comment.update({
+      where: {
+        id,
+      },
+      data: {
+        comment,
+      },
+    });
+
+    return NextResponse.json({ status: "OK", message: "コメントを更新しました", comment: updatedComment });
+  } catch(error) {
+    return handleError(error);
+  }
+}

--- a/src/app/api/diaries/[id]/comments/route.ts
+++ b/src/app/api/diaries/[id]/comments/route.ts
@@ -1,0 +1,31 @@
+import { handleError } from "@/app/utils/errorHandler";
+import { userAuthentication } from "@/app/utils/userAuthentication";
+import { PrismaClient } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+
+const prisma = new PrismaClient();
+
+// コメント作成
+export const POST = async(request: NextRequest, { params } : { params : {id: string }} ) => {
+  const { id } = params
+  const { data, error } = await userAuthentication(request);
+  if (error) return handleError(error);
+
+  const body = await request.json();
+  const { comment } = body;
+
+  try {
+    const currentUserId = data.user.id;
+    const postComment = await prisma.comment.create({
+      data: {
+        comment,
+        ownerId: currentUserId,
+        diaryId: id
+      },
+    });
+
+    return NextResponse.json({ status: "OK", message: "コメント投稿しました", comment: postComment }, { status: 200 });
+  } catch(error) { 
+    return handleError(error);
+  }
+}

--- a/src/app/api/diaries/[id]/comments/route.ts
+++ b/src/app/api/diaries/[id]/comments/route.ts
@@ -2,6 +2,7 @@ import { handleError } from "@/app/utils/errorHandler";
 import { userAuthentication } from "@/app/utils/userAuthentication";
 import { PrismaClient } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
+import { Comment } from "@/_types/comment";
 
 const prisma = new PrismaClient();
 
@@ -12,7 +13,7 @@ export const POST = async(request: NextRequest, { params } : { params : {id: str
   if (error) return handleError(error);
 
   const body = await request.json();
-  const { comment } = body;
+  const { comment } : Comment = body;
 
   try {
     const currentUserId = data.user.id;

--- a/src/app/api/diaries/[id]/route.ts
+++ b/src/app/api/diaries/[id]/route.ts
@@ -17,7 +17,7 @@ export const GET = async(request:NextRequest, { params } : { params: {id: string
   try {
     const detailDiary = await prisma.diary.findUnique({
       where: {
-        id
+        id,
       },
       include: {
         diaryTags: {
@@ -27,6 +27,12 @@ export const GET = async(request:NextRequest, { params } : { params: {id: string
                 name: true
               },
             },
+          },
+        },
+        comments: {
+          select: {
+            comment: true,
+            ownerId: true,
           },
         },
       },

--- a/src/app/api/diaries/[id]/route.ts
+++ b/src/app/api/diaries/[id]/route.ts
@@ -32,7 +32,11 @@ export const GET = async(request:NextRequest, { params } : { params: {id: string
         comments: {
           select: {
             comment: true,
-            ownerId: true,
+            owner: {
+              select: {
+                nickname: true
+              },
+            },
           },
         },
       },

--- a/src/app/api/diaries/[id]/route.ts
+++ b/src/app/api/diaries/[id]/route.ts
@@ -59,7 +59,7 @@ export const PUT = async(request: NextRequest,  { params } : { params: {id: stri
   const currentUserId = data.user.id;
 
   try {
-    await verifyUser(currentUserId, id, prisma);
+    await verifyUser(currentUserId, id, prisma.diary);
 
     const updatedDiary = await prisma.$transaction(async(prisma) => {
       const diary = await prisma.diary.update({
@@ -110,7 +110,7 @@ export const DELETE = async(request: NextRequest, { params } : { params: { id: s
   if (error) return handleError(request)
 
   const currentUserId = data.user.id;
-  await verifyUser(currentUserId, id, prisma)
+  await verifyUser(currentUserId, id, prisma.diary)
   
   try {
     await prisma.$transaction(async(prisma) => {

--- a/src/app/utils/verifyUser.ts
+++ b/src/app/utils/verifyUser.ts
@@ -1,17 +1,19 @@
-import { PrismaClient } from "@prisma/client"
-
-export const verifyUser = async(userId: string, recordId: string, prisma: PrismaClient) => {
-  const record = await prisma.diary.findUnique({
+export const verifyUser = async<T extends {ownerId: string}>(
+  userId: string, 
+  recordId: string, 
+  model: { findUnique: (args : { where: { id: string } }) => Promise<T | null>}
+) => {
+  const record = await model.findUnique({
     where: {
       id: recordId
     },
   })
 
   if(!record) {
-    throw new Error("diary record not found.")
+    throw new Error("record not found.")
   }
 
   if ( userId !== record.ownerId) {
-    throw new Error("this authentication user doesn't match this diary record writer.")
+    throw new Error("this authentication user doesn't match this record's writer.")
   }
 }


### PR DESCRIPTION
## Why
コメントに関するCRUD機能を実装するため。

What
以下の実装を行うためにAPIを作成しました。
`/api/diaries/[id]/comments`と`/api/diaries/[id]/comments/[commentId]`をエンドポイントとしています。

- コメントの一覧表示(日記の詳細機能に追加）
- コメントの新規登録
- コメントの編集
- コメントの削除