### PR TITLE
お世話表示機能_フロント実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "wancare",
       "version": "0.1.0",
       "dependencies": {
+        "@fullcalendar/core": "^6.1.15",
+        "@fullcalendar/daygrid": "^6.1.15",
+        "@fullcalendar/react": "^6.1.15",
         "@prisma/client": "^5.21.1",
         "@supabase/supabase-js": "^2.46.1",
         "@types/uuid": "^10.0.0",
@@ -266,6 +269,35 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
       "license": "MIT"
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.15.tgz",
+      "integrity": "sha512-BuX7o6ALpLb84cMw1FCB9/cSgF4JbVO894cjJZ6kP74jzbUZNjtwffwRdA+Id8rrLjT30d/7TrkW90k4zbXB5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "preact": "~10.12.1"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.15.tgz",
+      "integrity": "sha512-j8tL0HhfiVsdtOCLfzK2J0RtSkiad3BYYemwQKq512cx6btz6ZZ2RNc/hVnIxluuWFyvx5sXZwoeTJsFSFTEFA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.15.tgz",
+      "integrity": "sha512-L0b9hybS2J4e7lq6G2CD4nqriyLEqOH1tE8iI6JQjAMTVh5JicOo5Mqw+fhU5bJ7hLfMw2K3fksxX3Ul1ssw5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15",
+        "react": "^16.7.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -5246,6 +5278,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@prisma/client": "^5.21.1",
         "@supabase/supabase-js": "^2.46.1",
         "@types/uuid": "^10.0.0",
+        "date-fns": "^4.1.0",
         "flowbite": "^2.5.2",
         "flowbite-react": "^0.10.2",
         "next": "^15.0.3",
@@ -2498,6 +2499,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debounce": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fullcalendar/core": "^6.1.15",
         "@fullcalendar/daygrid": "^6.1.15",
+        "@fullcalendar/interaction": "^6.1.15",
         "@fullcalendar/react": "^6.1.15",
         "@prisma/client": "^5.21.1",
         "@supabase/supabase-js": "^2.46.1",
@@ -283,6 +284,15 @@
       "version": "6.1.15",
       "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.15.tgz",
       "integrity": "sha512-j8tL0HhfiVsdtOCLfzK2J0RtSkiad3BYYemwQKq512cx6btz6ZZ2RNc/hVnIxluuWFyvx5sXZwoeTJsFSFTEFA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.15.tgz",
+      "integrity": "sha512-DOTSkofizM7QItjgu7W68TvKKvN9PSEEvDJceyMbQDvlXHa7pm/WAVtAc6xSDZ9xmB1QramYoWGLHkCYbTW1rQ==",
       "license": "MIT",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.15"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seeds/seed.ts"
   },
   "dependencies": {
+    "@fullcalendar/core": "^6.1.15",
+    "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/react": "^6.1.15",
     "@prisma/client": "^5.21.1",
     "@supabase/supabase-js": "^2.46.1",
     "@types/uuid": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@fullcalendar/core": "^6.1.15",
     "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/interaction": "^6.1.15",
     "@fullcalendar/react": "^6.1.15",
     "@prisma/client": "^5.21.1",
     "@supabase/supabase-js": "^2.46.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@prisma/client": "^5.21.1",
     "@supabase/supabase-js": "^2.46.1",
     "@types/uuid": "^10.0.0",
+    "date-fns": "^4.1.0",
     "flowbite": "^2.5.2",
     "flowbite-react": "^0.10.2",
     "next": "^15.0.3",

--- a/src/app/_components/Carendar.tsx
+++ b/src/app/_components/Carendar.tsx
@@ -1,0 +1,17 @@
+import FullCalendar from '@fullcalendar/react'
+import dayGridPlugin from '@fullcalendar/daygrid' 
+
+const Calendar: () => JSX.Element = () => {
+  return (
+    <FullCalendar
+      plugins={[ dayGridPlugin ]}
+      initialView="dayGridMonth"
+      events={[
+        { title: 'event 1', date: '2024-12-08', backgroundColor: "blue" },
+        { title: 'event 2', date: '2024-12-10', backgroundColor: "red" }
+      ]}
+    />
+  )
+}
+
+export default Calendar;

--- a/src/app/_components/Carendar.tsx
+++ b/src/app/_components/Carendar.tsx
@@ -23,6 +23,7 @@ interface CalendarProps {
 interface ChangeCareLists {
   id: string;
   date: string;
+  time: string;
   title: string;
   amount?: number | null;
   memo?: string | null;
@@ -36,9 +37,11 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
 
   // カレンダー表示用の新しい配列を作成
   const changeCareLists = (cares: CareList[]) : ChangeCareLists[] => {
+    console.log(cares)
     return cares.map(care => ({
       id: care.id,
-      date: care.careDate.slice(0, 10), // 日付変換
+      date: care.careDate.slice(0, 10),
+      time: care.careDate.slice(12,16),
       title: care.careList.name,
       amount: care.amount,
       memo: care.memo,
@@ -56,8 +59,10 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
     console.log(eventLists)
   }
 
+  // カレンダー表示のカスタマイズ
+
   return (
-    <div className="h-screen overflow-y-auto">
+    <>
       <FullCalendar
         plugins={[ dayGridPlugin,interactionPlugin]}
         timeZone="UTC"
@@ -71,20 +76,23 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
         events={updatedCares}
       />
 
-
       <div className="py-10">
         <h3 className="text-primary text-start text-xl font-bold mb-5">記録</h3>
-        <ul>
+        <ul className="flex flex-col gap-1">
           {selectEvent.map((event) => {
             return(
-              <li key={event.id}>
-                {event.title}
+              <li key={event.id} className="border rounded-full py-2 px-4 shadow-md flex items-center gap-4">
+                <div className="flex items-center gap-2">
+                  <span className={`${event.careIcon} w-5 h-5`}></span>
+                  <span className="min-w-20">{event.title}</span>
+                </div>
+                <span>{event.time}</span>
               </li>
             )
           })}
         </ul>
       </div>
-    </div>
+    </>
   )
 }
 

--- a/src/app/_components/Carendar.tsx
+++ b/src/app/_components/Carendar.tsx
@@ -17,23 +17,35 @@ interface CalendarProps {
   cares: CareList[];
 }
 
+interface ChangeCareLists {
+  id: string;
+  date: string;
+  title: string;
+  amount?: number | null;
+  memo?: string | null;
+  imageKey: string | null;
+  careIcon: string;
+}
+
 const Calendar: React.FC<CalendarProps> = ({ cares }) => {
   const originalList = cares;
   // console.log(cares)
 
   // 時間の表示を変換
-  const changeCareLists = (cares) => {
-    return cares.map(care => {
-      care.date = care.careDate.slice(0, 10); // 日付変換
-      care.title = care.careList.name;
-      return care;
-    });
+  const changeCareLists = (cares: CareList[]) : ChangeCareLists[] => {
+    return cares.map(care => ({
+      id: care.id,
+      date: care.careDate.slice(0, 10), // 日付変換
+      title: care.careList.name,
+      amount: care.amount,
+      memo: care.memo,
+      imageKey: care.imageKey,
+      careName: care.careList.name,
+      careIcon: care.careList.icon,
+    }));
   }
 
   const updatedCares = changeCareLists(originalList);
-  console.log(updatedCares)
-
-
 
   return (
     <FullCalendar

--- a/src/app/_components/Carendar.tsx
+++ b/src/app/_components/Carendar.tsx
@@ -1,15 +1,49 @@
 import FullCalendar from '@fullcalendar/react'
 import dayGridPlugin from '@fullcalendar/daygrid' 
 
-const Calendar: () => JSX.Element = () => {
+interface CareList { 
+  id: string;
+  careDate: string;
+  amount?: number | null;
+  memo?: string | null;
+  imageKey: string | null;
+  careList: {
+    name: string;
+    icon: string;
+  }
+}
+
+interface CalendarProps { 
+  cares: CareList[];
+}
+
+const Calendar: React.FC<CalendarProps> = ({ cares }) => {
+  const originalList = cares;
+  // console.log(cares)
+
+  // 時間の表示を変換
+  const changeCareLists = (cares) => {
+    return cares.map(care => {
+      care.date = care.careDate.slice(0, 10); // 日付変換
+      care.title = care.careList.name;
+      return care;
+    });
+  }
+
+  const updatedCares = changeCareLists(originalList);
+  console.log(updatedCares)
+
+
+
   return (
     <FullCalendar
       plugins={[ dayGridPlugin ]}
+      timeZone="UTC"
       initialView="dayGridMonth"
-      events={[
-        { title: 'event 1', date: '2024-12-08', backgroundColor: "blue" },
-        { title: 'event 2', date: '2024-12-10', backgroundColor: "red" }
-      ]}
+      contentHeight="auto"
+      dayCellContent={ (e) => e.dayNumberText = e.dayNumberText.replace('日', '')} // カレンダーから日の文字を削除
+      locale="ja"
+      events={updatedCares}
     />
   )
 }

--- a/src/app/_components/Carendar.tsx
+++ b/src/app/_components/Carendar.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid'; 
 import interactionPlugin, { DateClickArg } from "@fullcalendar/interaction";
+import { parseISO, format } from 'date-fns'
+import IconButton from "./IconButton";
 
 interface CareList { 
   id: string;
@@ -39,8 +41,8 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
     console.log(cares)
     return cares.map(care => ({
       id: care.id,
-      date: care.careDate.slice(0, 10),
-      time: care.careDate.slice(12,16),
+      date: format(parseISO(care.careDate), "yyyy-MM-dd"),
+      time: format(parseISO(care.careDate), "HH:mm"),
       title: care.careList.name,
       amount: care.amount,
       memo: care.memo,
@@ -66,20 +68,24 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
         headerToolbar={{ start: "prev", center: "title", end: "next" }}
         initialView="dayGridMonth"
         contentHeight="auto"
-        dayMaxEvents={3} 
+        dayMaxEvents={2} 
         dayCellContent={ (e) => e.dayNumberText = e.dayNumberText.replace('日', '')} // カレンダーから日の文字を削除
         locale="ja"
         showNonCurrentDates={false}
         dateClick={handleDateClick}
         events={updatedCares}
+        eventColor={"#15A083"}
       />
 
       <div className="py-10">
-        <h3 className="text-primary text-start text-xl font-bold mb-5">記録</h3>
+        <div className="flex justify-between items-stretch mb-4">
+          <h3 className="text-primary text-start text-2xl font-bold">記録</h3>
+          <IconButton iconName="i-material-symbols-add-rounded" buttonText="記録をつける" />
+        </div>
         <ul className="flex flex-col gap-1">
           {selectEvent.map((event) => {
             return(
-              <li key={event.id} className="border rounded-full py-2 px-4 shadow-md flex items-center gap-4">
+              <li key={event.id} className="border text-gray-800 rounded-full py-2 px-4 shadow-md flex items-center gap-4">
                 <div className="flex items-center gap-2">
                   <span className={`${event.careIcon} w-5 h-5`}></span>
                   <span className="min-w-20">{event.title}</span>

--- a/src/app/_components/Carendar.tsx
+++ b/src/app/_components/Carendar.tsx
@@ -3,7 +3,6 @@ import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid'; 
 import interactionPlugin, { DateClickArg } from "@fullcalendar/interaction";
 
-
 interface CareList { 
   id: string;
   careDate: string;
@@ -34,7 +33,7 @@ interface ChangeCareLists {
 const Calendar: React.FC<CalendarProps> = ({ cares }) => {
   const originalList = cares;
   const [selectEvent, setSelectEvent] = useState<ChangeCareLists[]>([]);
-
+  
   // カレンダー表示用の新しい配列を作成
   const changeCareLists = (cares: CareList[]) : ChangeCareLists[] => {
     console.log(cares)
@@ -50,8 +49,8 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
       careIcon: care.careList.icon,
     }));
   }
-
   const updatedCares = changeCareLists(originalList);
+
 
   const handleDateClick = (e: DateClickArg) => {
     const eventLists = updatedCares.filter((d) => d.date == e.dateStr)
@@ -59,13 +58,12 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
     console.log(eventLists)
   }
 
-  // カレンダー表示のカスタマイズ
-
   return (
     <>
       <FullCalendar
         plugins={[ dayGridPlugin,interactionPlugin]}
         timeZone="UTC"
+        headerToolbar={{ start: "prev", center: "title", end: "next" }}
         initialView="dayGridMonth"
         contentHeight="auto"
         dayMaxEvents={3} 

--- a/src/app/_components/Carendar.tsx
+++ b/src/app/_components/Carendar.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid'; 
 import interactionPlugin, { DateClickArg } from "@fullcalendar/interaction";
-import { parseISO, format } from 'date-fns'
+import { parseISO, format, startOfToday } from 'date-fns'
 import IconButton from "./IconButton";
 
 interface CareList { 
@@ -35,10 +35,8 @@ interface ChangeCareLists {
 const Calendar: React.FC<CalendarProps> = ({ cares }) => {
   const originalList = cares;
   const [selectEvent, setSelectEvent] = useState<ChangeCareLists[]>([]);
-  
   // カレンダー表示用の新しい配列を作成
   const changeCareLists = (cares: CareList[]) : ChangeCareLists[] => {
-    console.log(cares)
     return cares.map(care => ({
       id: care.id,
       date: format(parseISO(care.careDate), "yyyy-MM-dd"),
@@ -53,11 +51,16 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
   }
   const updatedCares = changeCareLists(originalList);
 
+  useEffect(() => {
+    const today = format(startOfToday(), "yyyy-MM-dd");
+    const todaysEvents = updatedCares.filter((d) => d.date === today);
+    setSelectEvent(todaysEvents);
+  }, [cares]);
+  
 
   const handleDateClick = (e: DateClickArg) => {
     const eventLists = updatedCares.filter((d) => d.date == e.dateStr)
     setSelectEvent(eventLists);
-    console.log(eventLists)
   }
 
   return (

--- a/src/app/_components/Carendar.tsx
+++ b/src/app/_components/Carendar.tsx
@@ -4,6 +4,7 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin, { DateClickArg } from "@fullcalendar/interaction";
 import { parseISO, format, startOfToday } from 'date-fns'
 import IconButton from "./IconButton";
+import Link from "next/link";
 
 interface CareList { 
   id: string;
@@ -83,7 +84,9 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
       <div className="py-10">
         <div className="flex justify-between items-stretch mb-4">
           <h3 className="text-primary text-start text-2xl font-bold">記録</h3>
-          <IconButton iconName="i-material-symbols-add-rounded" buttonText="記録をつける" />
+          <Link href="/cares/new">
+            <IconButton iconName="i-material-symbols-add-rounded" buttonText="記録をつける" />
+          </Link>
         </div>
         <ul className="flex flex-col gap-1">
           {selectEvent.map((event) => {

--- a/src/app/_components/Carendar.tsx
+++ b/src/app/_components/Carendar.tsx
@@ -1,5 +1,8 @@
-import FullCalendar from '@fullcalendar/react'
-import dayGridPlugin from '@fullcalendar/daygrid' 
+import React, { useState } from "react";
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid'; 
+import interactionPlugin, { DateClickArg } from "@fullcalendar/interaction";
+
 
 interface CareList { 
   id: string;
@@ -29,9 +32,9 @@ interface ChangeCareLists {
 
 const Calendar: React.FC<CalendarProps> = ({ cares }) => {
   const originalList = cares;
-  // console.log(cares)
+  const [selectEvent, setSelectEvent] = useState<ChangeCareLists[]>([]);
 
-  // 時間の表示を変換
+  // カレンダー表示用の新しい配列を作成
   const changeCareLists = (cares: CareList[]) : ChangeCareLists[] => {
     return cares.map(care => ({
       id: care.id,
@@ -47,16 +50,40 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
 
   const updatedCares = changeCareLists(originalList);
 
+  const handleDateClick = (e: DateClickArg) => {
+    const eventLists = updatedCares.filter((d) => d.date == e.dateStr)
+    setSelectEvent(eventLists);
+    console.log(eventLists)
+  }
+
   return (
-    <FullCalendar
-      plugins={[ dayGridPlugin ]}
-      timeZone="UTC"
-      initialView="dayGridMonth"
-      contentHeight="auto"
-      dayCellContent={ (e) => e.dayNumberText = e.dayNumberText.replace('日', '')} // カレンダーから日の文字を削除
-      locale="ja"
-      events={updatedCares}
-    />
+    <>
+      <FullCalendar
+        plugins={[ dayGridPlugin,interactionPlugin]}
+        timeZone="UTC"
+        initialView="dayGridMonth"
+        contentHeight="auto"
+        dayCellContent={ (e) => e.dayNumberText = e.dayNumberText.replace('日', '')} // カレンダーから日の文字を削除
+        locale="ja"
+        showNonCurrentDates={false}
+        dateClick={handleDateClick}
+        events={updatedCares}
+      />
+
+
+      <div>
+        <h3>記録</h3>
+        <ul>
+          {selectEvent.map((event) => {
+            return(
+              <li key={event.id}>
+                {event.title}
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    </>
   )
 }
 

--- a/src/app/_components/Carendar.tsx
+++ b/src/app/_components/Carendar.tsx
@@ -57,12 +57,13 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
   }
 
   return (
-    <>
+    <div className="h-screen overflow-y-auto">
       <FullCalendar
         plugins={[ dayGridPlugin,interactionPlugin]}
         timeZone="UTC"
         initialView="dayGridMonth"
         contentHeight="auto"
+        dayMaxEvents={3} 
         dayCellContent={ (e) => e.dayNumberText = e.dayNumberText.replace('日', '')} // カレンダーから日の文字を削除
         locale="ja"
         showNonCurrentDates={false}
@@ -71,8 +72,8 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
       />
 
 
-      <div>
-        <h3>記録</h3>
+      <div className="py-10">
+        <h3 className="text-primary text-start text-xl font-bold mb-5">記録</h3>
         <ul>
           {selectEvent.map((event) => {
             return(
@@ -83,7 +84,7 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
           })}
         </ul>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/src/app/cares/page.tsx
+++ b/src/app/cares/page.tsx
@@ -12,7 +12,6 @@ const CareIndex: React.FC = () => {
   const { token, session } = useSupabaseSession();
   const [cares, setCares] = useState([]);
 
-
   useEffect(() => {
     if(!token || !session) return;
     console.log(token)
@@ -43,13 +42,15 @@ const CareIndex: React.FC = () => {
   return(
     <>
     <div className="flex justify-center">
-      <div className="max-w-64 my-20 flex flex-col items-center">
+      <div className="max-w-64 mt-20 flex flex-col items-center">
         <h2 className="text-primary text-center text-2xl font-bold mb-10">お世話ログ</h2>
       </div>
     </div>
-    <div className="p-4">
-      <Calendar cares={cares} />
-    </div>
+      {/* カレンダーエリア */}
+      <div className="p-4 ">
+        <Calendar cares={cares} />
+      </div>
+
     <Toaster />
     </>
   )

--- a/src/app/cares/page.tsx
+++ b/src/app/cares/page.tsx
@@ -47,7 +47,7 @@ const CareIndex: React.FC = () => {
       </div>
     </div>
       {/* カレンダーエリア */}
-      <div className="p-4 ">
+      <div className="p-4">
         <Calendar cares={cares} />
       </div>
 

--- a/src/app/cares/page.tsx
+++ b/src/app/cares/page.tsx
@@ -1,20 +1,58 @@
-"use client";
+"use client"
 
-import React from "react";
+import React, { useEffect, useState } from "react";
+import Calendar from "../_components/Carendar";
+import { useRouteGuard } from "@/_hooks/useRouteGuard";
+import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
+import { toast, Toaster } from "react-hot-toast"
 
-const careIndex: React.FC = () => {
+const CareIndex: React.FC = () => {
+  useRouteGuard();
+  
+  const { token, session } = useSupabaseSession();
+  const [cares, setCares] = useState([]);
+
+
+  useEffect(() => {
+    if(!token || !session) return;
+    console.log(token)
+
+    const fetchCareLists = async() => {
+      try {
+        const response = await fetch("api/cares", {
+          headers: {
+            "Content-Type" : "application/json",
+            Authorization: token,
+          },
+        });
+
+        if (response.status !== 200) {
+          toast.error("読み込みができませんでした");
+          throw new Error("Not record.")
+        }
+
+        const { cares } = await response.json();
+        setCares(cares);
+      } catch(error) {
+        console.log(error);
+      }
+    }
+    fetchCareLists();
+  }, [token, session])
+
   return(
+    <>
     <div className="flex justify-center">
       <div className="max-w-64 my-20 flex flex-col items-center">
-      <h2 className="text-primary text-center text-2xl font-bold mb-10">お世話ログ</h2>
-      {/* カレンダー表示 */}
-      <div>
-
-      </div>
-
+        <h2 className="text-primary text-center text-2xl font-bold mb-10">お世話ログ</h2>
       </div>
     </div>
+    <div className="p-4">
+      <Calendar cares={cares} />
+    </div>
+    <Toaster />
+    </>
   )
 }
 
-export default careIndex;
+export default CareIndex;

--- a/src/app/cares/page.tsx
+++ b/src/app/cares/page.tsx
@@ -39,19 +39,21 @@ const CareIndex: React.FC = () => {
     fetchCareLists();
   }, [token, session])
 
+  
+
   return(
     <>
-    <div className="flex justify-center">
-      <div className="max-w-64 mt-20 flex flex-col items-center">
-        <h2 className="text-primary text-center text-2xl font-bold mb-10">お世話ログ</h2>
+      <div className="flex justify-center">
+        <div className="max-w-64 mt-20 flex flex-col items-center">
+          <h2 className="text-primary text-center text-2xl font-bold mb-10">お世話ログ</h2>
+        </div>
       </div>
-    </div>
       {/* カレンダーエリア */}
-      <div className="p-4">
+      <div className="p-4 pb-20 win-h-screen overflow-y-auto">
         <Calendar cares={cares} />
       </div>
 
-    <Toaster />
+      <Toaster />
     </>
   )
 }

--- a/src/app/cares/page.tsx
+++ b/src/app/cares/page.tsx
@@ -49,7 +49,7 @@ const CareIndex: React.FC = () => {
         </div>
       </div>
       {/* カレンダーエリア */}
-      <div className="p-4 pb-20 win-h-screen overflow-y-auto">
+      <div className="p-4 pb-20 win-h-screen overflow-y-auto text-gray-800">
         <Calendar cares={cares} />
       </div>
 

--- a/src/app/cares/page.tsx
+++ b/src/app/cares/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import React from "react";
+
+const careIndex: React.FC = () => {
+  return(
+    <div className="flex justify-center">
+      <div className="max-w-64 my-20 flex flex-col items-center">
+      <h2 className="text-primary text-center text-2xl font-bold mb-10">お世話ログ</h2>
+      {/* カレンダー表示 */}
+      <div>
+
+      </div>
+
+      </div>
+    </div>
+  )
+}
+
+export default careIndex;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,3 +26,9 @@ body {
     text-wrap: balance;
   }
 }
+
+
+/* fullCalendar用のcustomCSS */
+.fc-event-title, .fc-list-event-title {
+  font-size: 11px;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Sawarabi_Gothic } from "next/font/google";
 import Menu from "@/app/_components/Menu";
+import './globals.css';
 
 const SawarabiGothic = Sawarabi_Gothic({
   weight: "400",


### PR DESCRIPTION
# why
ユーザーがペットのお世話記録を確認できるようにするため。

## what
以下の実装を行いました。

- home画面からカレンダーアイコンをクリックするとお世話一覧ページに遷移する。
- お世話一覧ページで、過去の記録がカレンダー型式と項目型式で確認できる。
- カレンダーの日付をクリックすると、該当日の記録が表示される。
- 「記録をつける」ボタンをクリックすると、お世話記録のカテゴリーページに遷移する。