### PR TITLE
お世話編集機能_フロント実装

### DIFF
--- a/src/_hooks/useEditPreviewImage.ts
+++ b/src/_hooks/useEditPreviewImage.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import { supabase } from "../app/utils/supabase";
+
+export const useEditPreviewImage = (uploadedKey: string | null, bucketName: string, prevImage: string | null) => {
+  const [thumbnailImageUrl, setThumbnailImageUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchImage = async(img: string) => {
+  
+      const { data: { publicUrl}, } = await supabase.storage.from(bucketName).getPublicUrl(img);
+        setThumbnailImageUrl(publicUrl);
+      }
+  
+      if(uploadedKey) {
+        fetchImage(uploadedKey);
+      } else if (prevImage) {
+        fetchImage(prevImage)
+      }
+  }, [uploadedKey, prevImage, bucketName]);
+
+  return thumbnailImageUrl;
+}

--- a/src/_hooks/useUploadImage.ts
+++ b/src/_hooks/useUploadImage.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
+import { supabase } from "../app/utils/supabase";
+import { toast } from "react-hot-toast";
+
+export const useUploadImage = (imageKey: string | null, bucketName: string) => {
+  const [isUploading, setUploading] = useState<boolean>(false);
+  const [uploadedKey, setUploadedKey] = useState<string | null>(null);
+
+  useEffect(()=> {
+    const uploadImage = async () => {
+      if(!imageKey || imageKey.length === 0) return;
+
+      if(typeof imageKey[0] === "object") {
+        setUploading(true);
+
+        const file = imageKey[0];                   
+        const filePath = `private/${uuidv4()}`;
+        const { data, error } = await supabase.storage
+          .from(bucketName).upload(filePath, file, {
+            cacheControl: "3600",
+            upsert: false,
+          });
+
+        if (error) {
+          toast.error("画像のアップロードに失敗しました");
+          setUploading(false);
+          return;
+        }
+        setUploadedKey(data.path);
+        setUploading(false);
+      }
+    }
+    uploadImage();
+  },[imageKey, bucketName]);
+
+  return { isUploading, uploadedKey };
+}
+export default useUploadImage;

--- a/src/app/_components/DogForm.tsx
+++ b/src/app/_components/DogForm.tsx
@@ -8,6 +8,7 @@ import Label from "@/app/_components/Label";
 import { useEffect, useState } from "react";
 import LoadingButton from "@/app/_components/LoadingButton";
 import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
+import { useEditPreviewImage } from "@/_hooks/useEditPreviewImage";
 import { supabase } from "@/app/utils/supabase";
 import { v4 as uuidv4 } from "uuid";
 import { useRouteGuard } from "@/_hooks/useRouteGuard";
@@ -45,7 +46,7 @@ const DogForm: React.FC<DogFormProps> = ({ isEdit, dogInfo }) => {
   const [breeds, setBreeds] = useState<Breed[]>([]);
   const imageKey = watch("imageKey");
   const [uploadedKey, setUploadedKey] = useState<string | null>(null);
-  const [thumbnailImageUrl, setThumbnailImageUrl] = useState<string | null>(null);
+  const thumbnailImageUrl = useEditPreviewImage(uploadedKey, "profile_img", dogInfo?.imageKey ?? null);
   const [isUploading, setUploading] = useState<boolean>(true);
   const [isLoading, setLoading] = useState<boolean>(true);
 
@@ -100,23 +101,6 @@ const DogForm: React.FC<DogFormProps> = ({ isEdit, dogInfo }) => {
   
     uploadImage();
   }, [imageKey]); 
-
-  // 画像表示を行う処理
-  useEffect(() => {
-    const fetchImage = async(img: string) => {
-      const { data: { publicUrl}, } = await supabase.storage
-        .from("profile_img")
-        .getPublicUrl(img);
-      
-        setThumbnailImageUrl(publicUrl);
-      }
-
-    if (uploadedKey) {
-      fetchImage(uploadedKey);
-    } else if (dogInfo?.imageKey) {
-      fetchImage(dogInfo.imageKey);
-    }
-  }, [uploadedKey, dogInfo?.imageKey]);
 
   // 編集の場合の初期値設定
   useEffect(() => { 

--- a/src/app/_components/DogForm.tsx
+++ b/src/app/_components/DogForm.tsx
@@ -31,16 +31,7 @@ interface DogFormProps {
 const DogForm: React.FC<DogFormProps> = ({ isEdit, dogInfo }) => {
   useRouteGuard();
   
-  const { register, handleSubmit, reset, watch, setValue, formState: { errors, isSubmitting}} = useForm<DogRequest>({
-    defaultValues: {
-      imageKey: dogInfo?.imageKey || "",
-      breedId: dogInfo?.breedId || "",
-      sex: dogInfo?.sex || "",
-      name: dogInfo?.name || "",
-      birthDate: dogInfo?.birthDate?.split('T')[0] || "",
-      adoptionDate: dogInfo?.adoptionDate?.split('T')[0] || "",
-    }
-  });
+  const { register, handleSubmit, reset, watch, setValue, formState: { errors, isSubmitting}} = useForm<DogRequest>();
   const { token } = useSupabaseSession();
   const router = useRouter();
   const [breeds, setBreeds] = useState<Breed[]>([]);

--- a/src/app/cares/[id]/page.tsx
+++ b/src/app/cares/[id]/page.tsx
@@ -35,6 +35,7 @@ const CareDetail: React.FC = () => {
   const [careUnit, setUnit] = useState<string>("");
   const [isLoading, setLoading] = useState<boolean>(true);
   const [openModal, setOpenModal] = useState(false);
+  const [refresh, setRefresh] = useState<boolean>(false);
 
   useEffect(() => {
     if (!token) return;
@@ -59,10 +60,11 @@ const CareDetail: React.FC = () => {
       }
     }
     fetchCare();
-  }, [id, token]);
+  }, [id, token, refresh]);
 
   const ModalClose = () => {
     setOpenModal(false);
+    setRefresh(!refresh);
   }
 
   if (!care) return;

--- a/src/app/cares/[id]/page.tsx
+++ b/src/app/cares/[id]/page.tsx
@@ -7,6 +7,8 @@ import { usePreviewImage } from "@/_hooks/usePreviewImage";
 import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
 import { careUnitLists } from "@/_constants/careUnitLists";
 import Image from "next/image";
+import ModalWindow from "@/app/_components/ModalWindow";
+import CareForm from "../_components/CareForm";
 import IconButton from "@/app/_components/IconButton";
 import PageLoading from "@/app/_components/PageLoading";
 
@@ -32,6 +34,7 @@ const CareDetail: React.FC = () => {
   const [careTitle, setTitle] = useState<string>("");
   const [careUnit, setUnit] = useState<string>("");
   const [isLoading, setLoading] = useState<boolean>(true);
+  const [openModal, setOpenModal] = useState(false);
 
   useEffect(() => {
     if (!token) return;
@@ -58,62 +61,72 @@ const CareDetail: React.FC = () => {
     fetchCare();
   }, [id, token]);
 
+  const ModalClose = () => {
+    setOpenModal(false);
+  }
+
   if (!care) return;
 
   return(
     <>
       {!isLoading ? (
         <div className="flex justify-center text-gray-800">
-        <div className="min-w-64 my-20 flex flex-col items-center gap-6 px-4">
-          <h2 className="text-2xl font-bold text-center text-primary mb-6">お世話の詳細</h2>
-          <div className="w-full flex flex-col gap-6">
-            <div>
-              <p className="text-primary font-bold text-xl mb-2">日付</p>
-              <p>{changeFromISOtoDate(care.careDate, "dateTime")}</p>
-            </div>
-            {careTitle && (
+          <div className="min-w-64 my-20 flex flex-col items-center gap-6 px-4">
+            <h2 className="text-2xl font-bold text-center text-primary mb-6">お世話の詳細</h2>
+            <div className="w-full flex flex-col gap-6">
               <div>
-                <p className="text-primary font-bold text-xl mb-2">{care.careList.name}</p>
-                <div className="flex gap-2">
-                  <span>{careTitle}</span> 
-                  <div>
-                    <span>
-                      {care.amount}
-                      {careUnit}
-                    </span>
+                <p className="text-primary font-bold text-xl mb-2">日付</p>
+                <p>{changeFromISOtoDate(care.careDate, "dateTime")}</p>
+              </div>
+              {careTitle && (
+                <div>
+                  <p className="text-primary font-bold text-xl mb-2">{care.careList.name}</p>
+                  <div className="flex gap-2">
+                    <span>{careTitle}</span> 
+                    <div>
+                      <span>
+                        {care.amount}
+                        {careUnit}
+                      </span>
+                    </div>
                   </div>
                 </div>
+              )}
+              <div>
+                <p className="text-primary font-bold text-xl mb-2">メモ</p>
+                <p className="bg-white w-full h-20 rounded-lg shadow p-2">{care.memo ? care.memo : "記録なし"}</p>
               </div>
-            )}
-            <div>
-              <p className="text-primary font-bold text-xl mb-2">メモ</p>
-              <p className="bg-white w-full h-20 rounded-lg shadow p-2">{care.memo ? care.memo : "記録なし"}</p>
+              <div>
+                <p className="text-primary font-bold text-xl mb-2">写真</p>
+                {careImage ? (
+                    <Image 
+                      src={careImage}
+                      alt="careImage"
+                      width={256}
+                      height={144}
+                      priority={true}
+                      className="rounded-lg"
+                    />
+                  ) : (
+                    <div className="w-full h-40 border border-dashed border-primary rounded-lg shadow flex flex-col items-center justify-center">
+                      <span className="i-tabler-dog w-10 h-10"></span>
+                      <p>No Image</p>
+                    </div>
+                  )
+                }
+              </div>
             </div>
-            <div>
-              <p className="text-primary font-bold text-xl mb-2">写真</p>
-              {careImage ? (
-                  <Image 
-                    src={careImage}
-                    alt="careImage"
-                    width={256}
-                    height={144}
-                    className="rounded-lg"
-                  />
-                ) : (
-                  <div className="w-full h-40 border border-dashed border-primary rounded-lg shadow flex flex-col items-center justify-center">
-                    <span className="i-tabler-dog w-10 h-10"></span>
-                    <p>No Image</p>
-                  </div>
-                )
-              }
+            <div onClick={ () => setOpenModal(true)}>
+              <IconButton 
+                iconName="i-material-symbols-light-edit-square-outline"
+                buttonText="記録を編集"
+              />
             </div>
           </div>
-          <IconButton 
-            iconName="i-material-symbols-light-edit-square-outline"
-            buttonText="記録を編集"
-          />
+          <ModalWindow show={openModal} onClose={ModalClose} >
+            <CareForm careId={care.careListId} careName={care.careList.name} token={token} onClose={ModalClose} />
+          </ModalWindow>
         </div>
-      </div>
       ) : (
         <PageLoading />
       )}

--- a/src/app/cares/[id]/page.tsx
+++ b/src/app/cares/[id]/page.tsx
@@ -124,7 +124,7 @@ const CareDetail: React.FC = () => {
             </div>
           </div>
           <ModalWindow show={openModal} onClose={ModalClose} >
-            <CareForm careId={care.careListId} careName={care.careList.name} token={token} onClose={ModalClose} />
+            <CareForm careId={care.careListId} careName={care.careList.name} token={token} onClose={ModalClose} isEdit={true} careInfo={care}/>
           </ModalWindow>
         </div>
       ) : (

--- a/src/app/cares/[id]/page.tsx
+++ b/src/app/cares/[id]/page.tsx
@@ -106,6 +106,7 @@ const CareDetail: React.FC = () => {
                       alt="careImage"
                       width={256}
                       height={144}
+                      style={{ width: '100%', height: 'auto' }}
                       priority={true}
                       className="rounded-lg"
                     />

--- a/src/app/cares/_components/CareForm.tsx
+++ b/src/app/cares/_components/CareForm.tsx
@@ -194,12 +194,13 @@ const CareForm: React.FC<CareFormProps> = ({careId, careName, token, isEdit, car
             <FileInput 
               id="dropzone-file"
               className="hidden" 
-              {...register("imageKey")} />
+              {...register("imageKey")} 
+            />
           </Label>
         </div>
         <LoadingButton
           isSubmitting={isSubmitting}
-          buttonText="登録" 
+          buttonText={isEdit? "更新" : "登録"} 
         />
     </form>
     <Toaster />

--- a/src/app/cares/_components/CareForm.tsx
+++ b/src/app/cares/_components/CareForm.tsx
@@ -100,7 +100,7 @@ const CareForm: React.FC<CareFormProps> = ({careId, careName, token, isEdit, car
   const onSubmit: SubmitHandler<Care> = async (data) => {
     const req = {
       ...data,
-      imageKey: uploadedKey,
+      imageKey: uploadedKey || careInfo?.imageKey,
       careListId: careId,
     }
     

--- a/src/app/cares/_components/CareForm.tsx
+++ b/src/app/cares/_components/CareForm.tsx
@@ -24,7 +24,7 @@ interface CareDetail {
   careList: { name: string, icon: string };
 }
 
-interface Props {
+interface CareFormProps {
   careId: string;
   careName: string;
   token: string | null;
@@ -33,7 +33,7 @@ interface Props {
   onClose: () => void;
 }
 
-const CareForm: React.FC<Props> = ({careId, careName, token, isEdit, careInfo, onClose } ) => {
+const CareForm: React.FC<CareFormProps> = ({careId, careName, token, isEdit, careInfo, onClose } ) => {
 
   const { register, handleSubmit, reset, watch, setValue, formState: { errors, isSubmitting } } = useForm<Care>();
   const imageKey = watch("imageKey");
@@ -43,7 +43,6 @@ const CareForm: React.FC<Props> = ({careId, careName, token, isEdit, careInfo, o
   const unit = careUnitLists[careName]?.unit;
   const unitTitle = careUnitLists[careName]?.title;
   const excludeFields = ["ワクチン", "通院", "トリミング", "シャンプー", "爪切り"];
-  console.log(careInfo)
 
   useEffect(()=> {
     const uploadImage = async () => {
@@ -76,12 +75,8 @@ const CareForm: React.FC<Props> = ({careId, careName, token, isEdit, careInfo, o
   // 画像のプレビュー
   useEffect(() => {
     const fetchImage = async(img: string) => {
-      if(!uploadedKey) return;
 
-      const { data: { publicUrl}, } = await supabase.storage
-        .from("care_img")
-        .getPublicUrl(img);
-      
+      const { data: { publicUrl}, } = await supabase.storage.from("care_img").getPublicUrl(img);
         setThumbnailImageUrl(publicUrl);
       }
 
@@ -111,18 +106,18 @@ const CareForm: React.FC<Props> = ({careId, careName, token, isEdit, careInfo, o
     
     if(!token) return;
     try {
-      const response = await fetch("/api/cares/", {
+      const response = await fetch(isEdit ? `/api/cares/${careInfo?.id}` : "/api/cares/", {
         headers: {
           "Content-Type" : "application/json",
           Authorization: token,
         },
-        method: "POST",
+        method: isEdit? "PUT" : "POST",
         body: JSON.stringify(req),
       })
       
       if(response.status === 200) {
         reset();
-        toast.success("投稿が完了しました");
+        toast.success(isEdit? "更新しました" : "投稿が完了しました");
 
         // toast表示を待ってからClose
         setTimeout(()=> {
@@ -131,7 +126,7 @@ const CareForm: React.FC<Props> = ({careId, careName, token, isEdit, careInfo, o
       }
     } catch (error) {
       console.log(error);
-      toast.error("登録に失敗しました");
+      toast.error(isEdit? "更新に失敗しました" :"登録に失敗しました");
     }
 
   }

--- a/src/app/cares/_components/CareForm.tsx
+++ b/src/app/cares/_components/CareForm.tsx
@@ -3,14 +3,14 @@ import Textarea from "@/app/_components/Textarea";
 import LoadingButton from "@/app/_components/LoadingButton";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { FileInput, Label } from "flowbite-react";
-import { supabase } from "@/app/utils/supabase";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Care } from "@/_types/care";
 import { careUnitLists } from "@/_constants/careUnitLists";
 import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
-import { v4 as uuidv4 } from "uuid";
+
 import { toast, Toaster } from "react-hot-toast";
 import { useEditPreviewImage } from "@/_hooks/useEditPreviewImage";
+import { useUploadImage } from "@/_hooks/useUploadImage";
 
 interface CareDetail {
   id: string;
@@ -38,41 +38,11 @@ const CareForm: React.FC<CareFormProps> = ({careId, careName, token, isEdit, car
 
   const { register, handleSubmit, reset, watch, setValue, formState: { errors, isSubmitting } } = useForm<Care>();
   const imageKey = watch("imageKey");
-  const [uploadedKey, setUploadedKey] = useState<string | null>(null);
-  // const [thumbnailImageUrl, setThumbnailImageUrl] = useState<string | null>(null);
+  const { uploadedKey, isUploading } = useUploadImage(imageKey ?? null, "care_img");
   const thumbnailImageUrl = useEditPreviewImage(uploadedKey ?? null,"care_img", careInfo?.imageKey ?? null)
-  const [isUploading, setUploading] = useState<boolean>(false);
   const unit = careUnitLists[careName]?.unit;
   const unitTitle = careUnitLists[careName]?.title;
   const excludeFields = ["ワクチン", "通院", "トリミング", "シャンプー", "爪切り"];
-
-  useEffect(()=> {
-    const uploadImage = async () => {
-      if(!imageKey || imageKey.length === 0) return;
-
-      if(typeof imageKey[0] === "object") {
-        setUploading(true);
-
-        const file = imageKey[0];                   
-        const filePath = `private/${uuidv4()}`;
-        const { data, error } = await supabase.storage
-          .from("care_img")
-          .upload(filePath, file, {
-            cacheControl: "3600",
-            upsert: false,
-          });
-
-        if (error) {
-          toast.error("画像のアップロードに失敗しました");
-          setUploading(false);
-          return;
-        }
-        setUploadedKey(data.path);
-        setUploading(false);
-      }
-    }
-    uploadImage();
-  },[imageKey]);
 
   useEffect(() => {
     if(isEdit && careInfo) {

--- a/src/app/cares/_components/CareForm.tsx
+++ b/src/app/cares/_components/CareForm.tsx
@@ -10,6 +10,7 @@ import { careUnitLists } from "@/_constants/careUnitLists";
 import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
 import { v4 as uuidv4 } from "uuid";
 import { toast, Toaster } from "react-hot-toast";
+import { useEditPreviewImage } from "@/_hooks/useEditPreviewImage";
 
 interface CareDetail {
   id: string;
@@ -38,7 +39,8 @@ const CareForm: React.FC<CareFormProps> = ({careId, careName, token, isEdit, car
   const { register, handleSubmit, reset, watch, setValue, formState: { errors, isSubmitting } } = useForm<Care>();
   const imageKey = watch("imageKey");
   const [uploadedKey, setUploadedKey] = useState<string | null>(null);
-  const [thumbnailImageUrl, setThumbnailImageUrl] = useState<string | null>(null);
+  // const [thumbnailImageUrl, setThumbnailImageUrl] = useState<string | null>(null);
+  const thumbnailImageUrl = useEditPreviewImage(uploadedKey ?? null,"care_img", careInfo?.imageKey ?? null)
   const [isUploading, setUploading] = useState<boolean>(false);
   const unit = careUnitLists[careName]?.unit;
   const unitTitle = careUnitLists[careName]?.title;
@@ -71,21 +73,6 @@ const CareForm: React.FC<CareFormProps> = ({careId, careName, token, isEdit, car
     }
     uploadImage();
   },[imageKey]);
-
-  // 画像のプレビュー
-  useEffect(() => {
-    const fetchImage = async(img: string) => {
-
-      const { data: { publicUrl}, } = await supabase.storage.from("care_img").getPublicUrl(img);
-        setThumbnailImageUrl(publicUrl);
-      }
-
-      if(uploadedKey) {
-        fetchImage(uploadedKey);
-      } else if (careInfo?.imageKey) {
-        fetchImage(careInfo.imageKey)
-      }
-  }, [uploadedKey, careInfo?.imageKey]);
 
   useEffect(() => {
     if(isEdit && careInfo) {


### PR DESCRIPTION
# why
ユーザーがペットのお世話記録の編集をできるようにするため。

## what
以下の実装を行いました。

- お世話詳細ページで「記録を編集」ボタンをクリックするとモーダルが表示される。
- モーダル内で情報を編集して「更新」ボタンをクリックすると、データ更新がされる。
- データの更新がされたら、モーダルが閉じ詳細ページが表示される。
- 表示された詳細ページには更新後の内容が反映されている。
