### PR TITLE
日記登録機能_フロント実装 

### DIFF
--- a/src/_types/diary.ts
+++ b/src/_types/diary.ts
@@ -1,7 +1,7 @@
 export interface DiaryRequest {
-  title: string
-  content: string
-  imageKey?: string | null
-  tags?: string[] 
-  summaryId?: string | null
+  title: string;
+  content: string;
+  imageKey?: string | null;
+  tags?: string;
+  summaryId?: string | null;
 }

--- a/src/_types/diary.ts
+++ b/src/_types/diary.ts
@@ -1,4 +1,4 @@
-export interface Diary {
+export interface DiaryRequest {
   title: string
   content: string
   imageKey?: string | null

--- a/src/app/_components/DogForm.tsx
+++ b/src/app/_components/DogForm.tsx
@@ -139,7 +139,7 @@ const DogForm: React.FC<DogFormProps> = ({ isEdit, dogInfo }) => {
 
             <div className="mb-6">
               <Label id="性別" />
-              <div className="inline-block relative w-64">
+              <div className="inline-block w-64">
                 <select
                   className="block appearance-none border border-primary bg-white text-gray-800 w-full px-3 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline"
                   {...register("sex",{
@@ -152,16 +152,13 @@ const DogForm: React.FC<DogFormProps> = ({ isEdit, dogInfo }) => {
                     )
                   })}
                 </select>
-                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
-                  <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
-                </div>
               </div>
               <div className="text-red-500 text-xs mt-2">{errors.sex?.message}</div>
             </div>
 
             <div className="mb-6">
               <Label id="犬種" />
-              <div className="inline-block relative w-64">
+              <div className="inline-block w-64">
                 <select 
                   className="block appearance-none border border-primary bg-white text-gray-800 w-full px-3 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline"
                   {...register("breedId",{
@@ -174,9 +171,6 @@ const DogForm: React.FC<DogFormProps> = ({ isEdit, dogInfo }) => {
                     )
                   })}
                 </select>
-                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
-                  <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
-                </div>
               </div>
               <div className="text-red-500 text-xs mt-2">{errors.breedId?.message}</div>
             </div>

--- a/src/app/api/diaries/[id]/route.ts
+++ b/src/app/api/diaries/[id]/route.ts
@@ -1,7 +1,6 @@
 import { userAuthentication } from "@/app/utils/userAuthentication";
 import { NextRequest, NextResponse } from "next/server";
 import { handleError } from "@/app/utils/errorHandler";
-import { Diary } from "@/_types/diary";
 import { findOrCreateTag } from "@/app/utils/findOrCreateTag";
 import { verifyUser } from "@/app/utils/verifyUser";
 import prisma from "@/libs/prisma";
@@ -57,7 +56,7 @@ export const PUT = async(request: NextRequest,  { params } : { params : Promise<
   const { data, error } = await userAuthentication(request);
   if (error) return handleError(request);
 
-  const { title, content, imageKey, tags, summaryId }: Diary = body;
+  const { title, content, imageKey, tags, summaryId } = body;
   const currentUserId = data.user.id;
 
   try {
@@ -85,8 +84,8 @@ export const PUT = async(request: NextRequest,  { params } : { params : Promise<
   
       if(tags && tags.length > 0) {
         // tagを紐付けし直す
-        const updateTags = tags.map(async(tag) => {
-          const updateTag = await findOrCreateTag(tag);
+        const updateTags = tags.map(async(tag: string) => {
+          const updateTag = await findOrCreateTag(tx, tag);
         
           await tx.diaryTag.create({
             data: {

--- a/src/app/api/diaries/route.ts
+++ b/src/app/api/diaries/route.ts
@@ -56,7 +56,6 @@ export const POST = async(request: NextRequest) => {
   
       // 既存タグか、新規タグかのチェックを行いDBに保存。
       if(tags && tags.length > 0) {
-        // const createTags = tags.map(async(tag: string) => {
         for(const tag of tags) {
           const addTag = await findOrCreateTag(tx, tag);
   

--- a/src/app/api/diaries/route.ts
+++ b/src/app/api/diaries/route.ts
@@ -2,7 +2,6 @@ import { userAuthentication } from "@/app/utils/userAuthentication";
 import prisma from "@/libs/prisma";
 import { NextRequest, NextResponse } from "next/server";
 import { handleError } from "@/app/utils/errorHandler";
-import { Diary } from "@/_types/diary";
 import { findOrCreateTag } from "@/app/utils/findOrCreateTag";
 
 
@@ -39,7 +38,7 @@ export const POST = async(request: NextRequest) => {
   if (error) return handleError(request);
 
   const body = await request.json();
-  const { title, content, imageKey, tags, summaryId }: Diary = body;
+  const { title, content, imageKey, tags, summaryId } = body;
 
   try {
     const currentUserId = data.user.id;
@@ -57,17 +56,17 @@ export const POST = async(request: NextRequest) => {
   
       // 既存タグか、新規タグかのチェックを行いDBに保存。
       if(tags && tags.length > 0) {
-        const createTags = tags.map(async(tag) => {
-          const addTag = await findOrCreateTag(tag);
+        // const createTags = tags.map(async(tag: string) => {
+        for(const tag of tags) {
+          const addTag = await findOrCreateTag(tx, tag);
   
-          return tx.diaryTag.create({
+          await tx.diaryTag.create({
             data: {
               diaryId: diary.id,
               tagId: addTag.id
             },
           });
-        })
-        await Promise.all(createTags);
+        }
       }
 
       return diary;

--- a/src/app/api/summaries/[id]/route.ts
+++ b/src/app/api/summaries/[id]/route.ts
@@ -78,7 +78,7 @@ export const PUT = async(request: NextRequest, { params } : { params : Promise<{
 
       if (tags && tags.length > 0) {
         const updateTags = tags.map(async(tag) => {
-          const addTag = await findOrCreateTag(tag);
+          const addTag = await findOrCreateTag(tx,tag);
 
           return tx.summaryTag.create({
             data: {

--- a/src/app/api/summaries/route.ts
+++ b/src/app/api/summaries/route.ts
@@ -16,9 +16,9 @@ export const POST = async(request: NextRequest) => {
   try {
     const currentUserId = data.user.id;
 
-    const addSummary = await prisma.$transaction(async(prisma) => {
+    const addSummary = await prisma.$transaction(async(tx) => {
       // summaryテーブルへの保存
-      const summary = await prisma.summary.create({
+      const summary = await tx.summary.create({
         data: {
           title,
           explanation,
@@ -29,9 +29,9 @@ export const POST = async(request: NextRequest) => {
       // 既存タグか、新規タグかのチェック
       if (tags && tags.length > 0) {
         const CreateTags = tags.map(async(tag) => {
-          const addTag = await findOrCreateTag(tag);
+          const addTag = await findOrCreateTag(tx, tag);
 
-          return prisma.summaryTag.create({
+          return tx.summaryTag.create({
             data: {
               summaryId: summary.id,
               tagId: addTag.id,
@@ -43,7 +43,7 @@ export const POST = async(request: NextRequest) => {
 
       if (diaryIds && diaryIds.length > 0) {
         const linkedSummary = diaryIds.map(async(id) => {
-          const diary = await prisma.diary.findUnique({
+          const diary = await tx.diary.findUnique({
             where: {
               id,
             },
@@ -53,7 +53,7 @@ export const POST = async(request: NextRequest) => {
             return NextResponse.json({ status: "Not Found", message: "diary Not found."}, { status: 404});
           }
 
-          await prisma.diary.update({
+          await tx.diary.update({
             where: { 
               id: diary.id
             },

--- a/src/app/api/users/[id]/summaries/route.ts
+++ b/src/app/api/users/[id]/summaries/route.ts
@@ -1,0 +1,31 @@
+import { handleError } from "@/app/utils/errorHandler";
+import { userAuthentication } from "@/app/utils/userAuthentication";
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/libs/prisma";
+
+export const GET = async(request: NextRequest, {params}: {params: Promise<{id: string}>} ) => {
+  const { id } = await params;
+  console.log(id)
+  const { error } = await userAuthentication(request);
+  if (error) return handleError(error);
+
+  try {
+    const summary = await prisma.summary.findMany({
+      where: {
+        ownerId: id,
+      },
+      select: {
+        id: true,
+        title: true,
+      },
+    })
+
+    if(!summary) {
+      return NextResponse.json({ status: "Not found", message: "summary not found"}, { status: 404});
+    }
+
+    return NextResponse.json({ status: "OK", summary: summary}, { status: 200});
+  } catch (error) {
+    return handleError(error);
+  }
+}

--- a/src/app/diaries/new/page.tsx
+++ b/src/app/diaries/new/page.tsx
@@ -20,7 +20,7 @@ interface SummaryResponse {
   title: string;
 }
 
-const AddDiary: React.FC<DiaryRequest> = () => {
+const AddDiary: React.FC = () => {
   useRouteGuard();
   const { token, session } = useSupabaseSession();
 

--- a/src/app/diaries/new/page.tsx
+++ b/src/app/diaries/new/page.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import React from "react";
+import Input from "@/app/_components/Input";
+import Textarea from "@/app/_components/Textarea";
+import { FileInput, Label } from "flowbite-react";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { useRouteGuard } from "@/_hooks/useRouteGuard";
+import { DiaryRequest } from "@/_types/diary";
+import { useEditPreviewImage } from "@/_hooks/useEditPreviewImage";
+import useUploadImage from "@/_hooks/useUploadImage";
+
+const AddDiary: React.FC<DiaryRequest> = () => {
+  useRouteGuard();
+  const { register, handleSubmit, reset, watch, formState: { errors, inSubmitting}} = useForm<DiaryRequest>();
+
+  const imageKey = watch("imageKey");
+  const { uploadedKey, isUploading } = useUploadImage(imageKey ?? null, "diary_img" );
+  const thumbnailImageUrl = useEditPreviewImage(uploadedKey ?? null, "diary_img", null);
+
+  return(
+    <div className="flex justify-center">
+      <form className="max-w-64 my-20 pb-20">
+        <h2 className="text-primary text-center text-2xl font-bold mb-10">日記投稿</h2>
+
+        <Input 
+          id="title"
+          labelName="タイトル"
+          type="text"
+          placeholder="アレルギーの検査"
+          register={{...register("title", {
+            required: "タイトルは必須です。"
+          })}}
+          error={errors.title?.message}
+        />
+
+        <Input 
+          id="tags"
+          labelName="タグ"
+          type="text"
+          placeholder="柴犬"
+          register={{...register("tags")}}
+          error={errors.title?.message}
+        />
+
+        <Textarea 
+          id="content"
+          labelName="内容"
+          placeholder="散歩の後に足に痒みが出てきた様子。"
+          register={{...register("content",{
+            required: "内容は必須です。"
+          })}}
+          error={errors.content?.message}
+        />
+
+        <div className="flex w-full items-center justify-center relative">
+          <Label
+            htmlFor="dropzone-file"
+            className="flex h-64 w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-primary bg-gray-50 hover:bg-gray-100"
+          >
+            <div className="flex flex-col items-center justify-center pb-6 pt-5">
+              {thumbnailImageUrl ? (
+                <div 
+                  className="absolute inset-0 h-64 w-full rounded-lg bg-cover bg-center pointer-events-none"
+                  style={{ backgroundImage: `url(${thumbnailImageUrl })` }}>
+                </div>
+              ) : (
+                <>
+                  <span className="i-tabler-cloud-upload w-8 h-8"></span>
+                  <p className="mb-2 text-xs text-gray-500">
+                    <span className="font-semibold">{isUploading ? "アップロード中": "画像をアップロード"}</span>
+                  </p>
+                </>
+              )}
+            </div>
+            <FileInput 
+              id="dropzone-file"
+              className="hidden" 
+              {...register("imageKey")} 
+            />
+          </Label>
+
+          <div className="mb-6">
+            <Label id="まとめに追加" />
+            <div className="inline-block relative w-64">
+              <select
+                className="block appearance-none border border-primary bg-white text-gray-800 w-full px-3 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline"
+                {...register("summaryId")}
+                >
+                <option value=""></option>
+                {summaryLists.map((summaryList) => {
+                  return(
+                    <option value={summaryList.name} key={summaryList.id}>{summaryList.name}</option>
+                  )
+                })}
+              </select>
+              <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
+                <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+              </div>
+            </div>
+            <div className="text-red-500 text-xs mt-2">{errors.summaryId?.message}</div>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}
+export default AddDiary;

--- a/src/app/diaries/new/page.tsx
+++ b/src/app/diaries/new/page.tsx
@@ -4,14 +4,15 @@ import React, { useEffect, useState } from "react";
 import Input from "@/app/_components/Input";
 import Textarea from "@/app/_components/Textarea";
 import { FileInput, Label } from "flowbite-react";
+import LoadingButton from "@/app/_components/LoadingButton";
+import { toast, Toaster } from "react-hot-toast";
+import PageLoading from "@/app/_components/PageLoading";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { useRouteGuard } from "@/_hooks/useRouteGuard";
-import { DiaryRequest } from "@/_types/diary";
 import { useEditPreviewImage } from "@/_hooks/useEditPreviewImage";
 import useUploadImage from "@/_hooks/useUploadImage";
 import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
-import LoadingButton from "@/app/_components/LoadingButton";
-import { toast, Toaster } from "react-hot-toast";
+import { DiaryRequest } from "@/_types/diary";
 
 interface SummaryResponse {
   id: string;
@@ -25,6 +26,7 @@ const AddDiary: React.FC<DiaryRequest> = () => {
   const userId = session?.user.id;
   const [summaryLists, setSummaryLists] = useState<SummaryResponse[]>([]);
   const [isLoading, setLoading] = useState<boolean>(true);
+
 
   const { register, handleSubmit, reset, watch, formState: { errors, isSubmitting}} = useForm<DiaryRequest>();
   const imageKey = watch("imageKey");
@@ -87,95 +89,101 @@ const AddDiary: React.FC<DiaryRequest> = () => {
   }
 
   return(
-    <div className="flex justify-center">
-      <form className="max-w-64 my-20 pb-20" onSubmit={handleSubmit(onSubmit)}>
-        <h2 className="text-primary text-center text-2xl font-bold mb-10">日記投稿</h2>
+    <>
+      {!isLoading ? (
+        <div className="flex justify-center">
+          <form className="max-w-64 my-20 pb-20" onSubmit={handleSubmit(onSubmit)}>
+            <h2 className="text-primary text-center text-2xl font-bold mb-10">日記投稿</h2>
 
-        <Input 
-          id="title"
-          labelName="タイトル"
-          type="text"
-          placeholder="アレルギーの検査"
-          register={{...register("title", {
-            required: "タイトルは必須です。"
-          })}}
-          error={errors.title?.message}
-        />
-
-        <Input 
-          id="tags"
-          labelName="タグ"
-          type="text"
-          placeholder="柴犬 アレルギー"
-          register={{...register("tags")}}
-          error={errors.tags?.message}
-        />
-
-        <Textarea 
-          id="content"
-          labelName="内容"
-          placeholder="散歩の後に足に痒みが出てきた様子。"
-          register={{...register("content",{
-            required: "内容は必須です。"
-          })}}
-          error={errors.content?.message}
-        />
-
-        <div className="flex w-full items-center justify-center relative">
-          <Label
-            htmlFor="dropzone-file"
-            className="flex h-64 w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-primary bg-gray-50 hover:bg-gray-100"
-          >
-            <div className="flex flex-col items-center justify-center pb-6 pt-5">
-              {thumbnailImageUrl ? (
-                <div 
-                  className="absolute inset-0 h-64 w-full rounded-lg bg-cover bg-center pointer-events-none"
-                  style={{ backgroundImage: `url(${thumbnailImageUrl })` }}>
-                </div>
-              ) : (
-                <>
-                  <span className="i-tabler-cloud-upload w-8 h-8"></span>
-                  <p className="mb-2 text-xs text-gray-500">
-                    <span className="font-semibold">{isUploading ? "アップロード中": "画像をアップロード"}</span>
-                  </p>
-                </>
-              )}
-            </div>
-            <FileInput 
-              id="dropzone-file"
-              className="hidden" 
-              {...register("imageKey")} 
+            <Input 
+              id="title"
+              labelName="タイトル"
+              type="text"
+              placeholder="アレルギーの検査"
+              register={{...register("title", {
+                required: "タイトルは必須です。"
+              })}}
+              error={errors.title?.message}
             />
-          </Label>
-        </div>
 
-        <div className="my-6">
-          <label className="block text-primary text-sm font-bold mb-2" id="summaryId">
-            まとめに追加する
-          </label>
-          <div className="inline-block w-64">
-            <select
-              className="block appearance-none border border-primary bg-white text-gray-800 w-full px-3 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline"
-              {...register("summaryId")}
+            <Input 
+              id="tags"
+              labelName="タグ"
+              type="text"
+              placeholder="柴犬 アレルギー"
+              register={{...register("tags")}}
+              error={errors.tags?.message}
+            />
+
+            <Textarea 
+              id="content"
+              labelName="内容"
+              placeholder="散歩の後に足に痒みが出てきた様子。"
+              register={{...register("content",{
+                required: "内容は必須です。"
+              })}}
+              error={errors.content?.message}
+            />
+
+            <div className="flex w-full items-center justify-center relative">
+              <Label
+                htmlFor="dropzone-file"
+                className="flex h-64 w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-primary bg-gray-50 hover:bg-gray-100"
               >
-              <option value="">追加しない</option>
-              {summaryLists.map((summaryList) => {
-                return(
-                  <option value={summaryList.id} key={summaryList.id}>{summaryList.title}</option>
-                )
-              })} 
-            </select>
-          </div>
-          <div className="text-red-500 text-xs mt-2">{errors.summaryId?.message}</div>
-        </div>
+                <div className="flex flex-col items-center justify-center pb-6 pt-5">
+                  {thumbnailImageUrl ? (
+                    <div 
+                      className="absolute inset-0 h-64 w-full rounded-lg bg-cover bg-center pointer-events-none"
+                      style={{ backgroundImage: `url(${thumbnailImageUrl })` }}>
+                    </div>
+                  ) : (
+                    <>
+                      <span className="i-tabler-cloud-upload w-8 h-8"></span>
+                      <p className="mb-2 text-xs text-gray-500">
+                        <span className="font-semibold">{isUploading ? "アップロード中": "画像をアップロード"}</span>
+                      </p>
+                    </>
+                  )}
+                </div>
+                <FileInput 
+                  id="dropzone-file"
+                  className="hidden" 
+                  {...register("imageKey")} 
+                />
+              </Label>
+            </div>
 
-        <LoadingButton 
-          isSubmitting={isSubmitting}
-          buttonText={"登録"}
-        />
-      </form>
-      <Toaster />
-    </div>
+            <div className="my-6">
+              <label className="block text-primary text-sm font-bold mb-2" id="summaryId">
+                まとめに追加する
+              </label>
+              <div className="inline-block w-64">
+                <select
+                  className="block appearance-none border border-primary bg-white text-gray-800 w-full px-3 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline"
+                  {...register("summaryId")}
+                  >
+                  <option value="">追加しない</option>
+                  {summaryLists.map((summaryList) => {
+                    return(
+                      <option value={summaryList.id} key={summaryList.id}>{summaryList.title}</option>
+                    )
+                  })} 
+                </select>
+              </div>
+              <div className="text-red-500 text-xs mt-2">{errors.summaryId?.message}</div>
+            </div>
+
+            <LoadingButton 
+              isSubmitting={isSubmitting}
+              buttonText={"登録"}
+            />
+          </form>
+          <Toaster />
+        </div>
+      ) : (
+        <PageLoading />
+      )}
+    </>
   )
 }
 export default AddDiary;

--- a/src/app/diaries/new/page.tsx
+++ b/src/app/diaries/new/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from "react";
 import Input from "@/app/_components/Input";
 import Textarea from "@/app/_components/Textarea";
+import IconButton from "@/app/_components/IconButton";
 import { FileInput, Label } from "flowbite-react";
 import LoadingButton from "@/app/_components/LoadingButton";
 import { toast, Toaster } from "react-hot-toast";
@@ -153,7 +154,7 @@ const AddDiary: React.FC<DiaryRequest> = () => {
               </Label>
             </div>
 
-            <div className="my-6">
+            <div className="mt-6 mb-3">
               <label className="block text-primary text-sm font-bold mb-2" id="summaryId">
                 まとめに追加する
               </label>
@@ -171,6 +172,13 @@ const AddDiary: React.FC<DiaryRequest> = () => {
                 </select>
               </div>
               <div className="text-red-500 text-xs mt-2">{errors.summaryId?.message}</div>
+            </div>
+
+            <div className="text-right">
+              <IconButton
+                iconName="i-material-symbols-add-rounded" 
+                buttonText="まとめを作成" 
+              />
             </div>
 
             <LoadingButton 

--- a/src/app/utils/findOrCreateTag.ts
+++ b/src/app/utils/findOrCreateTag.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 
 export const findOrCreateTag = async(tx: Prisma.TransactionClient, tag: string) => {
   const tagName = await tx.tag.upsert({

--- a/src/app/utils/findOrCreateTag.ts
+++ b/src/app/utils/findOrCreateTag.ts
@@ -1,7 +1,7 @@
-import prisma from "@/libs/prisma";
+import { PrismaClient, Prisma } from "@prisma/client";
 
-export const findOrCreateTag = async(tag: string) => {
-  const tagName = await prisma.tag.upsert({
+export const findOrCreateTag = async(tx: Prisma.TransactionClient, tag: string) => {
+  const tagName = await tx.tag.upsert({
     where: {
       name: tag
     },


### PR DESCRIPTION
# what
ユーザーがペットの日記記録を登録できるようにするため。

# why
以下の実装を行いました。

- /diaries/newページに遷移すると日記の登録ページが表示される。
- タイトル、タグ、内容、写真、紐づけるまとめ一覧を登録できる。
- まとめ一覧はユーザーが登録したまとめがプルダウンで選択できる。
- 入力フォームを埋めて登録ボタンをクリックすると、データベースにデータ登録ができる。