### PR TITLE
日記詳細表示機能_フロント実装

### DIFF
--- a/src/_types/tag.ts
+++ b/src/_types/tag.ts
@@ -1,0 +1,6 @@
+export interface Tag{
+  id: string;
+  diaryId: string;
+  tag: {id: string, name: string}
+  tagId: string;
+}

--- a/src/app/_components/IconButton.tsx
+++ b/src/app/_components/IconButton.tsx
@@ -5,13 +5,15 @@ import React from "react"
 interface ButtonProps {
   iconName: string;
   buttonText: string;
+  color: string;
+  textColor: string;
 }
 
-const IconButton: React.FC<ButtonProps> = ({iconName, buttonText}) => {
+const IconButton: React.FC<ButtonProps> = ({iconName, buttonText, color, textColor}) => {
   return(
     <button 
       type="button"
-      className="text-white font-bold bg-primary hover:bg-emerald-500 rounded-full text-sm px-3 py-1.5 text-center inline-flex items-center">
+      className={`${textColor} ${color} rounded-full text-sm px-3 py-1.5 text-center inline-flex items-center`}>
       <span className={`${iconName} w-5 h-5 mr-1`}></span>
       {buttonText}
     </button>

--- a/src/app/cares/[id]/page.tsx
+++ b/src/app/cares/[id]/page.tsx
@@ -106,7 +106,6 @@ const CareDetail: React.FC = () => {
                       alt="careImage"
                       width={256}
                       height={144}
-                      style={{ width: '100%', height: 'auto' }}
                       priority={true}
                       className="rounded-lg"
                     />

--- a/src/app/cares/[id]/page.tsx
+++ b/src/app/cares/[id]/page.tsx
@@ -122,6 +122,8 @@ const CareDetail: React.FC = () => {
               <IconButton 
                 iconName="i-material-symbols-light-edit-square-outline"
                 buttonText="記録を編集"
+                color="bg-primary"
+                textColor="text-white"
               />
             </div>
           </div>

--- a/src/app/cares/_components/Carendar.tsx
+++ b/src/app/cares/_components/Carendar.tsx
@@ -87,7 +87,12 @@ const Calendar: React.FC<CalendarProps> = ({ cares }) => {
         <div className="flex justify-between items-stretch mb-4">
           <h3 className="text-primary text-start text-2xl font-bold">記録</h3>
           <Link href="/cares/new">
-            <IconButton iconName="i-material-symbols-add-rounded" buttonText="記録をつける" />
+            <IconButton 
+              iconName="i-material-symbols-add-rounded"
+              buttonText="記録をつける"
+              color="bg-primary"
+              textColor="text-white"
+            />
           </Link>
         </div>
         <ul className="flex flex-col gap-1">

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import React, { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
+import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
+import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
+import { Tag } from "@/_types/tag";
+
+interface DiaryDetail {
+  id: string;
+  title: string;
+  content: string;
+  imageKey: string | null;
+  ownerId: string;
+  summaryId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  diaryTags: Tag[] | null;
+  comments: {comment: string, nickname: string}
+}
+
+const DiaryDetail: React.FC = () => {
+  const params = useParams();
+  const { id } = params;
+  const { token } = useSupabaseSession();
+  const [diary, setDiary] = useState<DiaryDetail | null >(null);
+  // const thumbnailImage = useState(null);
+
+  useEffect(() => {
+    if (!token) return;
+
+    const fetchDiary = async() => {
+      try {
+        const res = await fetch(`/api/diaries/${id}`, {
+          headers: {
+            "Content-Type" : "application/json",
+            Authorization: token,
+          },
+        });
+
+        const { diary } = await res.json();
+        console.log(diary)
+        setDiary(diary);
+      } catch(error) {
+        console.log(error);
+      }
+    }
+    fetchDiary()
+  }, [id, token]);
+
+  if (!diary) return;
+
+  return(
+    <div className="flex justify-center">
+      <div className="min-w-64 my-20 flex flex-col">
+        {/* 日付タイトルエリア */}
+        <div>
+          <p>投稿日{changeFromISOtoDate(diary.createdAt, "date")}</p>
+          <h2>タイトル</h2>
+        </div>
+        {/* 日付タイトルエリア */}
+
+        {/* 編集・削除ボタン */}
+        <div>
+          <span>編集</span>
+          <span>削除</span>
+        </div>
+        {/* 編集・削除ボタン */}
+
+        {/* 画像表示エリア */}
+        <div>
+          画像エリア
+        </div>
+        {/* 画像表示エリア */}
+
+        {/* 本文エリア */}
+        <div>
+
+        </div>
+        {/* 本文エリア */}
+
+        {/* タグ表示エリア */}
+        <div>
+          <span>タグ名</span>
+        </div>
+        {/* タグ表示エリア */}
+
+
+        {/* ブックマーク/コメントタブエリア */}
+        <div className="flex">
+          <div className="w-1/2 p-2 text-center border border-primary solid rounded bg-primary text-white flex items-center justify-center gap-1">
+            <span className="i-mdi-chat-processing-outline"></span>
+            <span className="text-sm">コメントする</span>
+          </div>
+          <div className="w-1/2 p-2 text-center border border-primary solid rounded flex items-center justify-center gap-1">
+            <span className="i-material-symbols-bookmark-add-outline"></span>
+            <span className="text-sm">ブックマーク</span>
+          </div>
+        </div>
+        {/* ブックマーク/コメント投稿エリア */}
+
+
+      </div>
+    </div>
+  )
+}
+export default DiaryDetail;

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -57,14 +57,12 @@ const DiaryDetail: React.FC = () => {
   return(
     <div className="flex justify-center">
       <div className="max-w-64 my-20 flex flex-col">
-        {/* 日付タイトルエリア */}
-        <div>
+        <div className="mb-8">
           <p>{changeFromISOtoDate(diary.createdAt, "date")}</p>
           <h2 className="text-2xl border-b-2 border-gray-700 pb-2">
             {diary.title}
           </h2>
         </div>
-        {/* 日付タイトルエリア */}
 
         {session?.user.id === diary.ownerId && (
           <div className="flex justify-end gap-2 my-2">

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -4,7 +4,10 @@ import React, { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
+import { usePreviewImage } from "@/_hooks/usePreviewImage";
+import no_diary_img from "@/public/no_diary_img.png";
 import { Tag } from "@/_types/tag";
+import Image from "next/image";
 
 interface DiaryDetail {
   id: string;
@@ -24,7 +27,8 @@ const DiaryDetail: React.FC = () => {
   const { id } = params;
   const { token } = useSupabaseSession();
   const [diary, setDiary] = useState<DiaryDetail | null >(null);
-  // const thumbnailImage = useState(null);
+  const thumbnailImage = usePreviewImage(diary?.imageKey ?? null, "diary_img")
+  console.log(thumbnailImage)
 
   useEffect(() => {
     if (!token) return;
@@ -52,42 +56,59 @@ const DiaryDetail: React.FC = () => {
 
   return(
     <div className="flex justify-center">
-      <div className="min-w-64 my-20 flex flex-col">
+      <div className="max-w-64 my-20 flex flex-col">
         {/* 日付タイトルエリア */}
         <div>
-          <p>投稿日{changeFromISOtoDate(diary.createdAt, "date")}</p>
-          <h2>タイトル</h2>
+          <p>{changeFromISOtoDate(diary.createdAt, "date")}</p>
+          <h2 className="text-2xl border-b-2 border-gray-700 pb-2">
+            {diary.title}
+          </h2>
         </div>
         {/* 日付タイトルエリア */}
 
         {/* 編集・削除ボタン */}
-        <div>
-          <span>編集</span>
-          <span>削除</span>
+        <div className="flex justify-end gap-2 my-2">
+          <span className="text-sm">編集</span>
+          <span className="text-sm">削除</span>
         </div>
         {/* 編集・削除ボタン */}
 
         {/* 画像表示エリア */}
-        <div>
-          画像エリア
+        <div className="relative w-full h-[256px]">
+          <Image 
+            src={thumbnailImage ? thumbnailImage : no_diary_img}
+            alt="diary Image"
+            fill
+            priority
+            style={{ objectFit: "cover"}}
+          />
         </div>
         {/* 画像表示エリア */}
 
         {/* 本文エリア */}
-        <div>
-
+        <div className="min-h-20 p-2 mt-6 mb-2 bg-white rounded-lg">
+          {diary.content}  
         </div>
         {/* 本文エリア */}
 
         {/* タグ表示エリア */}
-        <div>
-          <span>タグ名</span>
+        <div className="min-h-6 text-primary font-bold">
+          {diary.diaryTags && diary.diaryTags.length > 0 && (
+            diary.diaryTags.map((tag) => (
+              <span 
+                key={tag.id}
+                className="mr-2"
+              >
+                {`#${tag.tag.name}`}
+              </span>
+            ))
+          )}
         </div>
         {/* タグ表示エリア */}
 
 
         {/* ブックマーク/コメントタブエリア */}
-        <div className="flex">
+        <div className="flex my-8">
           <div className="w-1/2 p-2 text-center border border-primary solid rounded bg-primary text-white flex items-center justify-center gap-1">
             <span className="i-mdi-chat-processing-outline"></span>
             <span className="text-sm">コメントする</span>

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -26,10 +26,9 @@ interface DiaryDetail {
 const DiaryDetail: React.FC = () => {
   const params = useParams();
   const { id } = params;
-  const { token } = useSupabaseSession();
+  const { token, session } = useSupabaseSession();
   const [diary, setDiary] = useState<DiaryDetail | null >(null);
   const thumbnailImage = usePreviewImage(diary?.imageKey ?? null, "diary_img")
-  console.log(thumbnailImage)
 
   useEffect(() => {
     if (!token) return;
@@ -67,22 +66,22 @@ const DiaryDetail: React.FC = () => {
         </div>
         {/* 日付タイトルエリア */}
 
-        {/* 編集・削除ボタン */}
-        <div className="flex justify-end gap-2 my-2">
-          <IconButton
-            iconName="i-material-symbols-light-edit-square-outline"
-            buttonText="編集"
-            color="bg-primary"
-            textColor="text-white" 
-          />
-          <IconButton
-            iconName="i-material-symbols-light-edit-square-outline"
-            buttonText="削除" 
-            color="bg-secondary"
-            textColor="text-gray-800"
-          />
-        </div>
-        {/* 編集・削除ボタン */}
+        {session?.user.id === diary.ownerId && (
+          <div className="flex justify-end gap-2 my-2">
+            <IconButton
+              iconName="i-material-symbols-light-edit-square-outline"
+              buttonText="編集"
+              color="bg-primary"
+              textColor="text-white" 
+            />
+            <IconButton
+              iconName="i-material-symbols-light-edit-square-outline"
+              buttonText="削除" 
+              color="bg-secondary"
+              textColor="text-gray-800"
+            />
+          </div>
+        )}
 
         {/* 画像表示エリア */}
         <div className="relative w-full h-[256px]">

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
 import { usePreviewImage } from "@/_hooks/usePreviewImage";
 import no_diary_img from "@/public/no_diary_img.png";
+import IconButton from "@/app/_components/IconButton";
 import { Tag } from "@/_types/tag";
 import Image from "next/image";
 
@@ -68,8 +69,18 @@ const DiaryDetail: React.FC = () => {
 
         {/* 編集・削除ボタン */}
         <div className="flex justify-end gap-2 my-2">
-          <span className="text-sm">編集</span>
-          <span className="text-sm">削除</span>
+          <IconButton
+            iconName="i-material-symbols-light-edit-square-outline"
+            buttonText="編集"
+            color="bg-primary"
+            textColor="text-white" 
+          />
+          <IconButton
+            iconName="i-material-symbols-light-edit-square-outline"
+            buttonText="削除" 
+            color="bg-secondary"
+            textColor="text-gray-800"
+          />
         </div>
         {/* 編集・削除ボタン */}
 

--- a/src/app/diaries/_components/LoadingDiary.tsx
+++ b/src/app/diaries/_components/LoadingDiary.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const LoadingDiary: React.FC = () => {
-  const skeletons = Array(8).fill(0);
+  const skeletons = Array(6).fill(0);
 
   return(
     <div className="grid grid-cols-2 md:grid-cols-3 gap-4">

--- a/src/app/diaries/new/page.tsx
+++ b/src/app/diaries/new/page.tsx
@@ -178,6 +178,8 @@ const AddDiary: React.FC = () => {
               <IconButton
                 iconName="i-material-symbols-add-rounded" 
                 buttonText="まとめを作成" 
+                color="bg-secondary"
+                textColor="text-gray-800"
               />
             </div>
 

--- a/src/app/diaries/page.tsx
+++ b/src/app/diaries/page.tsx
@@ -6,22 +6,16 @@ import InfiniteScroll from 'react-infinite-scroller';
 import DiaryUnit from "./_components/DiaryUnit";
 import LoadingDiary from "./_components/LoadingDiary";
 import Link from "next/link";
+import { Tag } from "@/_types/tag";
 
 interface diaryIndex {
   id: string;
   title: string;
   content: string;
   imageKey: string | null;
-  diaryTags: tags[] | null;
+  diaryTags: Tag[] | null;
   summaryId: string | null;
   createdAt: string;
-}
-
-interface tags {
-  id: string;
-  diaryId: string;
-  tag: {id: string, name: string}
-  tagId: string;
 }
 
 const RecordIndex: React.FC = () => {

--- a/src/app/dogs/new/page.tsx
+++ b/src/app/dogs/new/page.tsx
@@ -20,6 +20,8 @@ const addDog: React.FC = () => {
           <IconButton 
             iconName="i-material-symbols-add-rounded"
             buttonText="ペットを登録する"
+            color="bg-primary"
+            textColor="text-white"
           />
         </Link>
       </div>

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -125,6 +125,8 @@ const Home: React.FC = () => {
                   <IconButton 
                   iconName="i-material-symbols-light-edit-square-outline"
                   buttonText="Edit"
+                  color="bg-primary"
+                  textColor="text-white"
                   />
                 </Link>
               </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -34,7 +34,7 @@ const config: Config = {
         foreground: "var(--foreground)",
         main: "#f5ebda",
         primary: "#326a55",
-        secondary: "#eead6b",
+        secondary: "#FBC95C",
       },
       width: {
         'main': '450px',


### PR DESCRIPTION
# why
ユーザーが日記記録の詳細確認をできるようにするため。

# what
以下の実装を行いました。

- 日記一覧から該当の日記をクリックする詳細ページに遷移する。
- 詳細ページでは、記録した日付や詳細項目、メモ、画像が確認できる。
- 日記の投稿者の場合は、「編集」「削除」ボタンが表示される。