### PR TITLE
日記削除機能_フロント実装

### DIFF
--- a/src/app/_components/DeleteAlert.tsx
+++ b/src/app/_components/DeleteAlert.tsx
@@ -1,0 +1,44 @@
+" use client"
+
+interface DeleteProps {
+  onDelete: () => Promise<void>;
+  onClose: () => void;
+  deleteObj: string;
+}
+
+const DeleteAlert: React.FC<DeleteProps> = ({ onDelete, onClose, deleteObj }) => {
+
+  return(
+    <>
+      <div id="alert-additional-content-2" className="p-4 mb-4 text-red-800 border border-red-800 rounded-lg dark:bg-gray-800 dark:text-red-400 dark:border-red-800" role="alert">
+        <div className="flex items-center">
+          <span className="i-material-symbols-warning-outline w-6 h-6 mr-2"></span>
+          <h3 className="text-lg font-bold">注意</h3>
+        </div>
+        <div className="mt-2 mb-4 text-sm">
+          <p>一度{deleteObj}を削除すると、復旧できません。</p>
+          <p>本当に削除しますか？</p>
+        </div>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            className="text-white bg-red-800 hover:bg-red-900 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-xs px-3 py-1.5 me-2 text-center inline-flex items-center dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-800"
+            onClick={onDelete}
+            >
+            削除
+          </button>
+          <button 
+            type="button"
+            className="text-red-800 bg-transparent border border-red-800 hover:bg-red-900 hover:text-white focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-xs px-3 py-1.5 text-center dark:hover:bg-red-600 dark:border-red-600 dark:text-red-500 dark:hover:text-white dark:focus:ring-red-800" data-dismiss-target="#alert-additional-content-2"
+            aria-label="Close"
+            onClick={onClose}
+            >
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default DeleteAlert;

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -15,6 +15,7 @@ import DiaryForm from "../_components/DiaryForm";
 import  PageLoading  from "@/app/_components/PageLoading";
 import { toast, Toaster } from "react-hot-toast"
 import DeleteAlert from "@/app/_components/DeleteAlert";
+import deleteStorageImage from "@/app/utils/deleteStorageImage";
 
 const DiaryDetail: React.FC = () => {
   const params = useParams();
@@ -56,15 +57,20 @@ const DiaryDetail: React.FC = () => {
       });
 
       if (response.status === 200) {
+        const deleteImage = diary?.imageKey as string;
+        await deleteStorageImage(deleteImage, "diary_img");
+        
         toast.success("日記を削除しました");
-        router.push("/diaries");
+        setTimeout(() => {
+          router.push("/diaries");
+        }, 2000);
       } else {        
-        toast.error("削除に失敗しました");
         throw new Error("Failed to delete.");
       }
 
     } catch(error) {
       console.log(error);
+      toast.error("削除に失敗しました");
     }
   }
   
@@ -179,11 +185,7 @@ const DiaryDetail: React.FC = () => {
       ) : (
         <PageLoading />
       )}
-      {/* {showDeleteAlert && (
-        <DeleteAlert />
-      )} */}
       <Toaster />
-      
     </>
   )
 }

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -14,6 +14,7 @@ import ModalWindow from "@/app/_components/ModalWindow";
 import DiaryForm from "../_components/DiaryForm";
 import  PageLoading  from "@/app/_components/PageLoading";
 import { toast, Toaster } from "react-hot-toast"
+import DeleteAlert from "@/app/_components/DeleteAlert";
 
 const DiaryDetail: React.FC = () => {
   const params = useParams();
@@ -25,17 +26,25 @@ const DiaryDetail: React.FC = () => {
   const [openModal, setOpenModal] = useState(false);
   const [refresh, setRefresh] = useState<boolean>(false);
   const [isLoading, setLoading] = useState<boolean>(true);
+  const [isEditMode, setIsEditMode] = useState(false);
 
   const ModalClose = () => {
     setOpenModal(false);
     setRefresh(!refresh);
   }
 
-  const handleDelete = async() => {
+  const openEditModal = () => {
+    setIsEditMode(true);
+    setOpenModal(true);
+  };
+
+  const openDeleteModal = () => {
+    setIsEditMode(false);
+    setOpenModal(true);
+  };
+
+  const handleDelete = async () => {
     if(!token) return;
-
-    
-
     try {
       const response = await fetch(`/api/diaries/${id}`, {
         headers: {
@@ -57,7 +66,7 @@ const DiaryDetail: React.FC = () => {
       console.log(error);
     }
   }
-
+  
   useEffect(() => {
     if (!token) return;
 
@@ -107,7 +116,7 @@ const DiaryDetail: React.FC = () => {
             {session?.user.id === diary.ownerId && (
               <>
               <div className="flex justify-end gap-2 my-2">
-                <div onClick={() => setOpenModal(true)}>
+                <div onClick={() => openEditModal()}>
                   <IconButton
                     iconName="i-material-symbols-light-edit-square-outline"
                     buttonText="編集"
@@ -115,9 +124,9 @@ const DiaryDetail: React.FC = () => {
                     textColor="text-white" 
                   />
                 </div>
-                <div onClick={() => handleDelete()}>
+                <div onClick={() => openDeleteModal()}>
                   <IconButton
-                    iconName="i-material-symbols-light-edit-square-outline"
+                    iconName="i-material-symbols-light-delete-outline"
                     buttonText="削除" 
                     color="bg-secondary"
                     textColor="text-gray-800"
@@ -125,7 +134,12 @@ const DiaryDetail: React.FC = () => {
                 </div>
               </div>
               <ModalWindow show={openModal} onClose={ModalClose} >
-                <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />
+                {isEditMode ? (
+                  <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />
+                ): (
+                  <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="日記" />
+                ) 
+                }
               </ModalWindow>
               </>
             )}
@@ -164,7 +178,11 @@ const DiaryDetail: React.FC = () => {
       ) : (
         <PageLoading />
       )}
+      {/* {showDeleteAlert && (
+        <DeleteAlert />
+      )} */}
       <Toaster />
+      
     </>
   )
 }

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -21,6 +21,7 @@ const DiaryDetail: React.FC = () => {
   const router = useRouter();
   const { id } = params;
   const { token, session } = useSupabaseSession();
+  const currentUserId = session?.user.id;
   const [diary, setDiary] = useState<DiaryDetails | null >(null);
   const thumbnailImage = usePreviewImage(diary?.imageKey ?? null, "diary_img")
   const [openModal, setOpenModal] = useState(false);
@@ -44,7 +45,7 @@ const DiaryDetail: React.FC = () => {
   };
 
   const handleDelete = async () => {
-    if(!token) return;
+    if(!token || currentUserId !== diary?.ownerId) return;
     try {
       const response = await fetch(`/api/diaries/${id}`, {
         headers: {

--- a/src/app/utils/deleteStorageImage.ts
+++ b/src/app/utils/deleteStorageImage.ts
@@ -1,0 +1,15 @@
+import { supabase } from "@/app/utils/supabase";
+
+export const useDeleteStorageImage = async (image: string, bucketName: string) => {
+  try {
+    const { error } = await supabase.storage.from(bucketName).remove([image]);
+    if(error) {
+      throw error;
+    }
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+} 
+
+export default useDeleteStorageImage;


### PR DESCRIPTION
# why
ユーザーが投稿済みの日記を削除できるようにするため。

# what
以下の実装を行いました。

- 日記の詳細ページで削除ボタンをクリックすると削除確認用のダイアログが表示される。
- ダイアログ上でキャンセルボタンをクリックすると、ダイアログが閉じる。
- ダイアログ上で削除ボタンをクリックすると、データベース上から日記を削除する。
- 日記の削除をすると、紐づいたStorage上の画像データも削除される。
- 削除が完了したら、日記一覧ページに遷移する。
- 削除した日記は日記投稿一覧ページからも削除される。

