### PR TITLE
お世話削除機能_フロント実装

### DIFF
--- a/src/app/cares/[id]/page.tsx
+++ b/src/app/cares/[id]/page.tsx
@@ -28,7 +28,7 @@ interface CareDetail {
 const CareDetail: React.FC = () => {
   const params = useParams();
   const { id } = params;
-  const { token } = useSupabaseSession();
+  const { token, session } = useSupabaseSession();
   const [care, setCare] = useState<CareDetail | null>(null);
   const careImage = usePreviewImage(care?.imageKey ?? null, "care_img");
   const [careTitle, setTitle] = useState<string>("");
@@ -36,6 +36,7 @@ const CareDetail: React.FC = () => {
   const [isLoading, setLoading] = useState<boolean>(true);
   const [openModal, setOpenModal] = useState(false);
   const [refresh, setRefresh] = useState<boolean>(false);
+  const [isEditMode, setIsEditMode] = useState(false);
 
   useEffect(() => {
     if (!token) return;
@@ -61,6 +62,16 @@ const CareDetail: React.FC = () => {
     }
     fetchCare();
   }, [id, token, refresh]);
+
+  const openEditModal = () => {
+    setIsEditMode(true);
+    setOpenModal(true);
+  };
+
+  const openDeleteModal = () => {
+    setIsEditMode(false);
+    setOpenModal(true);
+  };
 
   const ModalClose = () => {
     setOpenModal(false);
@@ -118,14 +129,26 @@ const CareDetail: React.FC = () => {
                 }
               </div>
             </div>
-            <div onClick={ () => setOpenModal(true)}>
-              <IconButton 
-                iconName="i-material-symbols-light-edit-square-outline"
-                buttonText="記録を編集"
-                color="bg-primary"
-                textColor="text-white"
-              />
-            </div>
+            {session?.user.id === care.ownerId && (
+              <div className="flex gap-4 my-2">
+                <div onClick={ () => openEditModal()}>
+                  <IconButton 
+                    iconName="i-material-symbols-light-edit-square-outline"
+                    buttonText="編集"
+                    color="bg-primary"
+                    textColor="text-white"
+                  />
+                </div>
+                <div onClick={() => openDeleteModal()}>
+                  <IconButton
+                    iconName="i-material-symbols-light-delete-outline"
+                    buttonText="削除" 
+                    color="bg-secondary"
+                    textColor="text-gray-800"
+                  />
+                </div>
+              </div>
+            )}
           </div>
           <ModalWindow show={openModal} onClose={ModalClose} >
             <CareForm careId={care.careListId} careName={care.careList.name} token={token} onClose={ModalClose} isEdit={true} careInfo={care}/>

--- a/src/app/cares/[id]/page.tsx
+++ b/src/app/cares/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useEffect, useState } from "react";
-import { useParams  } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import { usePreviewImage } from "@/_hooks/usePreviewImage";
 import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
@@ -11,6 +11,9 @@ import ModalWindow from "@/app/_components/ModalWindow";
 import CareForm from "../_components/CareForm";
 import IconButton from "@/app/_components/IconButton";
 import PageLoading from "@/app/_components/PageLoading";
+import { toast, Toaster } from "react-hot-toast"
+import DeleteAlert from "@/app/_components/DeleteAlert";
+import deleteStorageImage from "@/app/utils/deleteStorageImage";
 
 interface CareDetail {
   id: string;
@@ -29,6 +32,8 @@ const CareDetail: React.FC = () => {
   const params = useParams();
   const { id } = params;
   const { token, session } = useSupabaseSession();
+  const router = useRouter();
+  const currentUserId = session?.user.id;
   const [care, setCare] = useState<CareDetail | null>(null);
   const careImage = usePreviewImage(care?.imageKey ?? null, "care_img");
   const [careTitle, setTitle] = useState<string>("");
@@ -78,6 +83,35 @@ const CareDetail: React.FC = () => {
     setRefresh(!refresh);
   }
 
+  const handleDelete = async () => {
+    if(!token || currentUserId !== care?.ownerId) return;
+
+    try {
+      const response = await fetch(`/api/cares/${id}`, {
+        headers: {
+          "Content-Type" : "application/json",
+          Authorization: token,
+        },
+        method: "DELETE",
+      });
+
+      if (response.status === 200) {
+        const deleteImage = care?.imageKey as string;
+        await deleteStorageImage(deleteImage, "care_img");
+
+        toast.success("記録を削除しました");
+        setTimeout(() => {
+          router.push("/cares");
+        }, 2000);
+      } else {
+        throw new Error("Failed to delete.")
+      }
+    } catch(error) {
+      console.log(error);
+      toast.error("削除に失敗しました");
+    }
+  }
+ 
   if (!care) return;
 
   return(
@@ -151,12 +185,17 @@ const CareDetail: React.FC = () => {
             )}
           </div>
           <ModalWindow show={openModal} onClose={ModalClose} >
-            <CareForm careId={care.careListId} careName={care.careList.name} token={token} onClose={ModalClose} isEdit={true} careInfo={care}/>
+            {isEditMode ? (
+              <CareForm careId={care.careListId} careName={care.careList.name} token={token} onClose={ModalClose} isEdit={true} careInfo={care}/>
+            ) : (
+              <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="お世話記録"/>
+            )}
           </ModalWindow>
         </div>
       ) : (
         <PageLoading />
       )}
+      <Toaster />
     </>
   )
 }

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -156,7 +156,7 @@ const DiaryDetail: React.FC = () => {
               {diary.content}  
             </div>
     
-            <div className="min-h-6 text-primary font-bold">
+            <div className="min-h-6 text-primary font-bold text-gray-700">
               {diary.diaryTags && diary.diaryTags.length > 0 && (
                 diary.diaryTags.map((tag) => (
                   <span 

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import React, { useState, useEffect } from "react";
-import { useParams } from "next/navigation";
-import { useRouter } from "next/navigation"
+import { useParams, useRouter } from "next/navigation";
 import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
 import { usePreviewImage } from "@/_hooks/usePreviewImage";


### PR DESCRIPTION
why
ユーザーが投稿済みのお世話記録を削除できるようにするため。

what
以下の実装を行いました。

- お世話の詳細ページで削除ボタンをクリックすると削除確認用のダイアログが表示される。
- ダイアログ上でキャンセルボタンをクリックすると、ダイアログが閉じる。
- ダイアログ上で削除ボタンをクリックすると、データベース上からお世話記録を削除する。
- お世話記録の削除をすると、紐づいたStorage上の画像データも削除される。
- 削除が完了したら、お世話一覧ページ(カレンダー)に遷移する。
- 削除した記録は一覧ページからも削除される。