### PR TITLE
まとめ登録機能_フロント実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-hot-toast": "^2.4.1",
         "react-infinite-scroller": "^1.2.6",
         "react-loader-spinner": "^6.1.6",
+        "react-select": "^5.9.0",
         "recharts": "^2.13.3",
         "uuid": "^11.0.3"
       },
@@ -82,6 +83,82 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.26.5",
+        "@babel/types": "^7.26.5",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+      "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
@@ -89,6 +166,60 @@
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+      "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.5",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.5",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+      "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -141,6 +272,68 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/cache/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
@@ -156,10 +349,86 @@
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
       "license": "MIT"
     },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/serialize/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/serialize/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
     "node_modules/@emotion/unitless": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
       "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1389,6 +1658,12 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
     "node_modules/@types/phoenix": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.5.tgz",
@@ -1399,14 +1674,12 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1440,6 +1713,15 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
         "@types/react": "*"
       }
     },
@@ -2013,6 +2295,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2089,7 +2386,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2272,6 +2568,37 @@
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -2549,7 +2876,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2701,6 +3027,21 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
     },
     "node_modules/es-abstract": {
       "version": "1.23.3",
@@ -2872,7 +3213,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3435,6 +3775,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3876,6 +4222,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3890,7 +4245,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -4447,11 +4801,29 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -4634,6 +5006,12 @@
       "devOptional": true,
       "license": "ISC"
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4714,7 +5092,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -5042,13 +5419,30 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -5100,6 +5494,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -5510,6 +5913,27 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/react-select": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.9.0.tgz",
+      "integrity": "sha512-nwRKGanVHGjdccsnzhFte/PULziueZxGD8LL2WojON78Mvnq7LdAMEtu2frrwld1fr3geixg3iiMBIc/LLAZpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
@@ -5668,7 +6092,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5955,6 +6378,15 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -6695,6 +7127,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
+      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-hot-toast": "^2.4.1",
     "react-infinite-scroller": "^1.2.6",
     "react-loader-spinner": "^6.1.6",
+    "react-select": "^5.9.0",
     "recharts": "^2.13.3",
     "uuid": "^11.0.3"
   },

--- a/src/_types/summary.ts
+++ b/src/_types/summary.ts
@@ -1,3 +1,4 @@
+
 export interface Summary {
   title: string
   explanation: string
@@ -9,3 +10,10 @@ export interface SummaryResponse {
   id: string;
   title: string;
 } 
+
+export interface SummaryRequest {
+  title: string
+  explanation: string
+  tags? : string | null;
+  diaryIds? : string[] | null;
+}

--- a/src/app/_components/SearchForm.tsx
+++ b/src/app/_components/SearchForm.tsx
@@ -1,0 +1,18 @@
+const SearchForm: React.FC = () => {
+  return(
+    <form className="max-w-md my-6">   
+    <label id="default-search" className="mb-2 text-sm font-medium text-gray-900 sr-only">Search</label>
+    <div className="relative">
+      <div className="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+        <svg className="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+            <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+        </svg>
+      </div>
+      <input type="search" id="default-search" className="block w-full p-4 ps-10 text-sm text-gray-900 border border-primary rounded-full bg-gray-50 focus:ring-primary focus:border-primary" required />
+      <button type="submit" className="text-white absolute end-2.5 bottom-2.5 bg-primary hover:bg-primary focus:ring-4 focus:outline-none focus:ring-primary font-medium rounded-full text-sm px-4 py-2">検索</button>
+    </div>
+  </form>
+  )
+}
+
+export default SearchForm;

--- a/src/app/_components/Tab.tsx
+++ b/src/app/_components/Tab.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import  Link  from "next/link";
+
+const Tab: React.FC = () => {
+  return(
+  <div className="flex">
+    <div className="w-1/2 p-2 text-center border border-primary solid rounded bg-primary text-white">
+      <Link href="/diaries">
+        日記一覧
+      </Link>
+    </div>
+    <div className="w-1/2 p-2 text-center border border-primary solid rounded">
+      <Link href="/summaries" >
+        まとめ一覧
+      </Link>
+    </div>
+  </div>
+  )
+}
+export default Tab;

--- a/src/app/api/users/[id]/diaries/route.ts
+++ b/src/app/api/users/[id]/diaries/route.ts
@@ -1,0 +1,31 @@
+import { handleError } from "@/app/utils/errorHandler";
+import { userAuthentication } from "@/app/utils/userAuthentication";
+import prisma from "@/libs/prisma";
+import { NextRequest, NextResponse } from "next/server";
+
+
+export const GET = async (request: NextRequest, { params } : {params: Promise<{id: string}>} ) => {
+  const { id } = await params;
+  const { error } = await userAuthentication(request);
+  if (error) return handleError(error);
+
+  try {
+    const diaries = await prisma.diary.findMany({
+      where: {
+        ownerId: id,
+      },
+      select: {
+        id: true,
+        title: true,
+      },
+    })
+
+    if(!diaries) {
+      return NextResponse.json( { status: "Not found", message: "diaries not found"}, { status: 404});
+    }
+
+    return NextResponse.json({ status: "OK", diaries: diaries }, {status: 200 });
+  } catch (error) {
+    return handleError(error);
+  }
+} 

--- a/src/app/api/users/[id]/summaries/route.ts
+++ b/src/app/api/users/[id]/summaries/route.ts
@@ -5,7 +5,6 @@ import prisma from "@/libs/prisma";
 
 export const GET = async(request: NextRequest, {params}: {params: Promise<{id: string}>} ) => {
   const { id } = await params;
-  console.log(id)
   const { error } = await userAuthentication(request);
   if (error) return handleError(error);
 

--- a/src/app/diaries/_components/DiaryForm.tsx
+++ b/src/app/diaries/_components/DiaryForm.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import Input from "@/app/_components/Input";
 import Textarea from "@/app/_components/Textarea";
-import IconButton from "@/app/_components/IconButton";
 import { FileInput, Label } from "flowbite-react";
 import LoadingButton from "@/app/_components/LoadingButton";
 import { toast, Toaster } from "react-hot-toast";
@@ -152,15 +151,6 @@ const DiaryForm: React.FC<DiaryFormProps> = ({isEdit, diary, onClose}) => {
             </select>
           </div>
           <div className="text-red-500 text-xs mt-2">{errors.summaryId?.message}</div>
-        </div>
-
-        <div className="text-right">
-          <IconButton
-            iconName="i-material-symbols-add-rounded" 
-            buttonText="まとめを作成" 
-            color="bg-secondary"
-            textColor="text-gray-800"
-          />
         </div>
 
         <LoadingButton 

--- a/src/app/diaries/page.tsx
+++ b/src/app/diaries/page.tsx
@@ -8,6 +8,8 @@ import LoadingDiary from "./_components/LoadingDiary";
 import { DiaryDetails } from "@/_types/diary";
 import ModalWindow from "../_components/ModalWindow";
 import DiaryForm from "./_components/DiaryForm";
+import  Tab  from "@/app/_components/Tab";
+import  SearchForm  from "@/app/_components/SearchForm";
 
 const RecordIndex: React.FC = () => {
   const { token } = useSupabaseSession();
@@ -64,28 +66,11 @@ const RecordIndex: React.FC = () => {
   return(
     <div className="flex justify-center">
       <div className="my-20 pb-10 px-4 relative w-full max-w-screen-lg">
-        <div className="flex">
-          <div className="w-1/2 p-2 text-center border border-primary solid rounded bg-primary text-white">
-            日記一覧
-          </div>
-          <div className="w-1/2 p-2 text-center border border-primary solid rounded">
-            まとめ一覧
-          </div>
-        </div>
+         {/* Menuタブ*/}
+        <Tab />
 
         {/* 検索フォーム */}
-        <form className="max-w-md my-6">   
-          <label id="default-search" className="mb-2 text-sm font-medium text-gray-900 sr-only">Search</label>
-          <div className="relative">
-            <div className="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
-              <svg className="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-                  <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
-              </svg>
-            </div>
-            <input type="search" id="default-search" className="block w-full p-4 ps-10 text-sm text-gray-900 border border-primary rounded-full bg-gray-50 focus:ring-primary focus:border-primary" required />
-            <button type="submit" className="text-white absolute end-2.5 bottom-2.5 bg-primary hover:bg-primary focus:ring-4 focus:outline-none focus:ring-primary font-medium rounded-full text-sm px-4 py-2">検索</button>
-          </div>
-        </form>
+        <SearchForm />
 
         <InfiniteScroll 
           loadMore={fetchDiary}

--- a/src/app/summaries/_components/DiarySelection.tsx
+++ b/src/app/summaries/_components/DiarySelection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { OptionProps } from "react-Select";
+import { OptionProps } from "react-select";
 import { Option } from "../_types/Option";
 
 const DiarySelection: React.FC<OptionProps<Option>> = (props) => {

--- a/src/app/summaries/_components/DiarySelection.tsx
+++ b/src/app/summaries/_components/DiarySelection.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { OptionProps } from "react-Select";
+import { Option } from "../_types/Option";
+
+const DiarySelection: React.FC<OptionProps<Option>> = (props) => {
+  return(
+    <div className="w-full">
+      <input 
+        type="checkbox"
+        id={props.data.id}
+        onChange={() => props.selectOption(props.data)}
+        checked={props.isSelected}
+        className="m-2 rounded-full border border-primary"
+      />
+      <label htmlFor={props.data.id}>
+        {props.data.title}
+      </label>
+    </div>
+  )
+}
+
+export default DiarySelection;

--- a/src/app/summaries/_components/SummaryForm.tsx
+++ b/src/app/summaries/_components/SummaryForm.tsx
@@ -7,34 +7,13 @@ import Textarea from "@/app/_components/Textarea";
 import Label from "@/app/_components/Label";
 import LoadingButton from "@/app/_components/LoadingButton";
 import { toast, Toaster } from "react-hot-toast";
-import Select, { OptionProps, MultiValue } from "react-Select";
+import Select, { MultiValue, SingleValue } from "react-Select";
 import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
-
+import DiarySelection from "./DiarySelection";
+import { Option } from "../_types/Option";
 
 interface SummaryFormProps {
   onClose: () => void;
-}
-
-interface Option {
-  id: string;
-  title: string;
-}
-
-const DiarySelection = (props: OptionProps<Option>) => {
-  return(
-    <div className="w-full">
-      <input 
-        type="checkbox"
-        id={props.data.id}
-        onChange={() => props.selectOption(props.data)}
-        checked={props.isSelected}
-        className="m-2 rounded-full border border-primary"
-      />
-      <label htmlFor={props.data.id}>
-        {props.data.title}
-      </label>
-    </div>
-  )
 }
 
 const SummaryForm: React.FC<SummaryFormProps> = ({ onClose }) => {
@@ -78,7 +57,7 @@ const SummaryForm: React.FC<SummaryFormProps> = ({ onClose }) => {
     }
   }
 
-  const handleChange = (selectedIds: MultiValue<Option>) => {
+  const handleChange = (selectedIds: MultiValue<Option> | SingleValue<Option>) => {
     setSelectedDiaryIds(selectedIds as Option[]);
   }
 
@@ -104,7 +83,7 @@ const SummaryForm: React.FC<SummaryFormProps> = ({ onClose }) => {
       }
     }
     fetchDiaryList();
-  },[token]);
+  },[token, userId]);
 
   return(
     <div className="flex justify-center">
@@ -151,7 +130,7 @@ const SummaryForm: React.FC<SummaryFormProps> = ({ onClose }) => {
             getOptionValue={(option) => option.id}
             closeMenuOnSelect={false}
             isMulti
-            components={{Option: DiarySelection}}
+            components={{Option: DiarySelection }}
             styles={{
               control: (base) => ({
                 ...base,

--- a/src/app/summaries/_components/SummaryForm.tsx
+++ b/src/app/summaries/_components/SummaryForm.tsx
@@ -7,7 +7,7 @@ import Textarea from "@/app/_components/Textarea";
 import Label from "@/app/_components/Label";
 import LoadingButton from "@/app/_components/LoadingButton";
 import { toast, Toaster } from "react-hot-toast";
-import Select, { MultiValue, SingleValue } from "react-Select";
+import Select, { MultiValue, SingleValue } from "react-select";
 import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import DiarySelection from "./DiarySelection";
 import { Option } from "../_types/Option";

--- a/src/app/summaries/_components/SummaryForm.tsx
+++ b/src/app/summaries/_components/SummaryForm.tsx
@@ -1,0 +1,157 @@
+import React, { useState, useEffect } from "react";
+import { useRouteGuard } from "@/_hooks/useRouteGuard";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { Summary } from "@/_types/summary";
+import Input from "@/app/_components/Input";
+import Textarea from "@/app/_components/Textarea";
+import Label from "@/app/_components/Label";
+import LoadingButton from "@/app/_components/LoadingButton";
+import { toast, Toaster } from "react-hot-toast";
+import Select, { OptionProps, MultiValue } from "react-Select";
+import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
+
+
+interface SummaryFormProps {
+  onClose: () => void;
+}
+
+interface Option {
+  id: string;
+  title: string;
+}
+
+const DiarySelection = (props: OptionProps<Option>) => {
+  console.log(props)
+  return(
+    <div className="w-full">
+      <input 
+        type="checkbox"
+        id={props.data.id}
+        onChange={() => props.selectOption(props.data)}
+        checked={props.isSelected}
+        className="m-2 rounded-full"
+      />
+      <label htmlFor={props.data.id}>
+        {props.data.title}
+      </label>
+    </div>
+  )
+}
+
+const SummaryForm: React.FC<SummaryFormProps> = () => {
+  useRouteGuard();
+  const { token, session } = useSupabaseSession();
+  const useId = session?.user.id;
+  const {register, handleSubmit, reset, setValue, watch, formState: {errors, isSubmitting}} = useForm<Summary>();
+  const [selectedDiaryIds, setSelectedDiaryIds] = useState<Option[]>([]);
+  const [diaryLists, setDiaryLists] = useState<Option[]>([]);
+
+  const onSubmit: SubmitHandler<Summary> = async (data) => {
+    const req = {
+      ...data,
+      diaryIds: selectedDiaryIds
+    }
+  }
+
+
+  const handleChange = (selectedIds: MultiValue<Option>) => {
+    setSelectedDiaryIds(selectedIds as Option[]);
+  }
+
+  useEffect(() => {
+    if(!token) return;
+    const fetchDiaryList = async () => {
+      try {
+        const response = await fetch(`api/users/${useId}/summaries`, {
+          headers: {
+            "Content-Type" : "application/json",
+            Authorization: token,
+          },
+        });
+
+        if(response.status !== 200) {
+          throw new Error("Not record.")
+        }
+
+        const { summary } = await response.json();
+        console.log(summary)
+        setDiaryLists(summary);
+      } catch(error) {
+        console.log(error);
+      }
+    }
+    fetchDiaryList();
+  },[token]);
+
+  return(
+    <div className="flex justify-center">
+      <form className="max-w-64 my-8" onSubmit={handleSubmit(onSubmit)}>
+        <h2 className="text-primary text-center text-2xl font-bold mb-10">
+          まとめ投稿
+        </h2>
+
+        <Input 
+          id="title"
+          labelName="タイトル"
+          type="text"
+          placeholder="骨折の記録"
+          register={{...register("title", {
+            required: "タイトルは必須です。"
+          })}}
+          error={errors.title?.message}
+        />
+
+        <Input 
+          id="tags"
+          labelName="タグ"
+          type="text"
+          placeholder="骨折 シニア犬"
+          register={{...register("tags")}}
+          error={errors.tags?.message}
+        />
+
+        <Textarea 
+          id="explanation"
+          labelName="説明"
+          placeholder="骨折完治までの記録"
+          register={{...register("explanation",{
+            required: "内容は必須です。"
+          })}}
+          error={errors.explanation?.message}
+        />
+
+        <div className="mt-6 mb-3">
+          <Label id="まとめに登録する記事" />
+          <Select 
+            options={diaryLists}
+            getOptionLabel={(option) => option.title}
+            getOptionValue={(option) => option.id}
+            closeMenuOnSelect={false}
+            isMulti
+            components={{Option: DiarySelection}}
+            styles={{
+              multiValue: (base) => ({
+                ...base,
+                backgroundColor: "#326a55",
+                color: 'white',
+              }),
+              multiValueLabel: (base) => ({
+                ...base,
+                backgroundColor: "#326a55",
+                color: 'white',
+              }),
+            }}
+            onChange={handleChange}
+          />
+        </div>
+
+        <LoadingButton 
+          isSubmitting={isSubmitting}
+          buttonText={"登録"}
+        />
+      </form>
+      <Toaster />
+    </div>
+  )
+}
+export default SummaryForm;

--- a/src/app/summaries/_types/Option.ts
+++ b/src/app/summaries/_types/Option.ts
@@ -1,0 +1,4 @@
+export interface Option {
+  id: string;
+  title: string;
+}

--- a/src/app/summaries/page.tsx
+++ b/src/app/summaries/page.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import React , { useState } from "react";
+import Tab from "../_components/Tab";
+import SearchForm from "../_components/SearchForm";
+import ModalWindow from "../_components/ModalWindow";
+import SummaryForm from "./_components/SummaryForm";
+
+const SummaryIndex: React.FC = () => {
+  const [openModal, setOpenModal] = useState(false);
+
+  const ModalClose = () => {
+    setOpenModal(false);
+  }
+
+
+
+  return(
+    <div className="flex justify-center">
+      <div className="my-20 pb-10 px-4 relative w-full max-w-screen-lg">
+        <Tab />
+        <SearchForm />
+
+        {/* <InfiniteScroll>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            {diaryList.map((diary) => {
+                return(
+                  <DiaryUnit diary={diary} key={diary.id}/>
+                )
+              })
+            }
+          </div>
+        </InfiniteScroll> */}
+
+        {/* 新規投稿ボタン */}
+        <div className="flex justify-end sticky bottom-20 mt-4">
+            <div 
+              className="bg-primary text-white rounded-full w-12 h-12"
+              onClick={ () => setOpenModal(true)}
+              >
+              <span className="i-material-symbols-add-rounded text-white w-12 h-12">
+              </span>
+            </div>
+          <ModalWindow show={openModal} onClose={ModalClose}>
+            <SummaryForm onClose={ModalClose} />
+          </ModalWindow>
+        </div>
+      </div>
+    </div>
+  )
+}
+export default SummaryIndex;


### PR DESCRIPTION
## what
ユーザーが日記をグループ分けするための「まとめ」を登録できるようにするため。

## why
以下の実装を行いました。
- 日記一覧ページで「まとめ一覧」ボタンをクリックすると、/summariesのパスに遷移する。
- ＋アイコンをクリックするとまとめ登録用のモーダルが表示される。
- タイトル、タグ、説明、紐づける日記一覧を登録できる。
- 「まとめに登録する記事」はプルダウンで複数選択でき、ユーザーが登録したまとめが表示される。
- 入力フォームを記入して登録ボタンをクリックすると、データベースにデータ登録ができる。