### PR TITLE
まとめ詳細表示機能_フロント実装

### DIFF
--- a/src/_types/summary.ts
+++ b/src/_types/summary.ts
@@ -33,7 +33,7 @@ export interface SummaryDetails {
   explanation: string
   ownerId: string
   summaryTags: Tag[]
-  diaries: { title: string, createdAt: string }[]
+  diaries: { id: string, title: string, createdAt: string }[]
   createdAt: string
   updatedAt: string
 }

--- a/src/_types/summary.ts
+++ b/src/_types/summary.ts
@@ -19,10 +19,21 @@ export interface SummaryRequest {
   diaryIds? : string[] | null;
 }
 
-export interface SummaryDetails {
+export interface AllSummary {
   id: string
   title: string
   explanation: string
   createdAt: string
   summaryTags: Tag[]
+}
+
+export interface SummaryDetails {
+  id: string
+  title: string
+  explanation: string
+  ownerId: string
+  summaryTags: Tag[]
+  diaries: { title: string, createdAt: string }[]
+  createdAt: string
+  updatedAt: string
 }

--- a/src/app/_components/DeleteRoundButton.tsx
+++ b/src/app/_components/DeleteRoundButton.tsx
@@ -1,9 +1,16 @@
 import React from "react";
 
-const DeleteRoundButton: React.FC = () => {
+interface DeleteButtonProps {
+  DeleteClick?: () => void;
+}
+
+const DeleteRoundButton: React.FC<DeleteButtonProps> = ({DeleteClick}) => {
   return(
   <div>
-    <button className="flex items-center justify-center rounded-full bg-gray-300 p-2">
+    <button 
+      className="flex items-center justify-center rounded-full bg-gray-300 p-2"
+      onClick={DeleteClick}
+      >
       <span className="i-material-symbols-light-delete-outline w-8 h-8"></span>
     </button>
   </div>

--- a/src/app/_components/DeleteRoundButton.tsx
+++ b/src/app/_components/DeleteRoundButton.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const DeleteRoundButton: React.FC = () => {
+  return(
+  <div>
+    <button className="flex items-center justify-center rounded-full bg-gray-300 p-2">
+      <span className="i-material-symbols-light-delete-outline w-8 h-8"></span>
+    </button>
+  </div>
+  )
+}
+export default DeleteRoundButton;

--- a/src/app/_components/EditRoundButton.tsx
+++ b/src/app/_components/EditRoundButton.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 interface EditButtonProps {
   EditClick?: () => void;
-
 }
 
 const EditRoundButton: React.FC<EditButtonProps> = ({EditClick}) => {

--- a/src/app/_components/EditRoundButton.tsx
+++ b/src/app/_components/EditRoundButton.tsx
@@ -1,9 +1,17 @@
 import React from "react";
 
-const EditRoundButton: React.FC = () => {
+interface EditButtonProps {
+  EditClick?: () => void;
+
+}
+
+const EditRoundButton: React.FC<EditButtonProps> = ({EditClick}) => {
   return(
   <div>
-    <button className="flex items-center justify-center rounded-full bg-secondary p-2">
+    <button 
+      className="flex items-center justify-center rounded-full bg-secondary p-2"
+      onClick={EditClick}
+      >
       <span  className="i-material-symbols-light-edit-square-outline w-8 h-8"></span>
     </button>
   </div>

--- a/src/app/_components/EditRoundButton.tsx
+++ b/src/app/_components/EditRoundButton.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const EditRoundButton: React.FC = () => {
+  return(
+  <div>
+    <button className="flex items-center justify-center rounded-full bg-secondary p-2">
+      <span  className="i-material-symbols-light-edit-square-outline w-8 h-8"></span>
+    </button>
+  </div>
+  )
+}
+export default EditRoundButton;

--- a/src/app/api/summaries/[id]/route.ts
+++ b/src/app/api/summaries/[id]/route.ts
@@ -29,6 +29,7 @@ export const GET = async(request: NextRequest, {params} : { params : Promise<{ i
         },
         diaries: {
           select: {
+            id: true,
             title: true,
             createdAt: true
           },

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -15,6 +15,8 @@ import  PageLoading  from "@/app/_components/PageLoading";
 import { toast, Toaster } from "react-hot-toast"
 import DeleteAlert from "@/app/_components/DeleteAlert";
 import deleteStorageImage from "@/app/utils/deleteStorageImage";
+import EditRoundButton from "@/app/_components/EditRoundButton";
+import DeleteRoundButton from "@/app/_components/DeleteRoundButton";
 
 const DiaryDetail: React.FC = () => {
   const params = useParams();
@@ -101,6 +103,23 @@ const DiaryDetail: React.FC = () => {
       {(diary && !isLoading) ? (
         <div className="flex justify-center">
           <div className="max-w-64 my-20 flex flex-col">
+            <div className="flex justify-end gap-3 my-2">
+              {session?.user.id === diary.ownerId && (
+                <>
+                  <EditRoundButton EditClick={() => openEditModal()}/>
+                  <DeleteRoundButton />
+                </>
+              )}
+              <ModalWindow show={openModal} onClose={ModalClose} >
+                {isEditMode ? (
+                  <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />
+                ): (
+                  <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="日記" />
+                ) 
+                }
+              </ModalWindow>
+            </div>
+
             <div className="mb-6 text-gray-800">
               <p>{changeFromISOtoDate(diary.createdAt, "date")}</p>
               <h2 className="text-2xl border-b-2 border-gray-700 pb-2">

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -6,7 +6,6 @@ import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
 import { usePreviewImage } from "@/_hooks/usePreviewImage";
 import no_diary_img from "@/public/no_diary_img.png";
-import IconButton from "@/app/_components/IconButton";
 import { DiaryDetails } from "@/_types/diary";
 import Image from "next/image";
 import ModalWindow from "@/app/_components/ModalWindow";
@@ -107,7 +106,7 @@ const DiaryDetail: React.FC = () => {
               {session?.user.id === diary.ownerId && (
                 <>
                   <EditRoundButton EditClick={() => openEditModal()}/>
-                  <DeleteRoundButton />
+                  <DeleteRoundButton DeleteClick={() => openDeleteModal()}/>
                 </>
               )}
               <ModalWindow show={openModal} onClose={ModalClose} >
@@ -137,39 +136,7 @@ const DiaryDetail: React.FC = () => {
                 style={{ objectFit: "cover", borderRadius: "25px" }}
               />
             </div>
-    
-            {session?.user.id === diary.ownerId && (
-              <>
-              <div className="flex justify-end gap-2 my-2">
-                <div onClick={() => openEditModal()}>
-                  <IconButton
-                    iconName="i-material-symbols-light-edit-square-outline"
-                    buttonText="編集"
-                    color="bg-primary"
-                    textColor="text-white" 
-                  />
-                </div>
-                <div onClick={() => openDeleteModal()}>
-                  <IconButton
-                    iconName="i-material-symbols-light-delete-outline"
-                    buttonText="削除" 
-                    color="bg-secondary"
-                    textColor="text-gray-800"
-                  />
-                </div>
-              </div>
-              <ModalWindow show={openModal} onClose={ModalClose} >
-                {isEditMode ? (
-                  <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />
-                ): (
-                  <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="日記" />
-                ) 
-                }
-              </ModalWindow>
-              </>
-            )}
-    
-    
+
             <div className="min-h-20 p-2 mt-6 mb-2 bg-white rounded-lg">
               {diary.content}  
             </div>

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import React, { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
+import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
+import { SummaryDetails } from "@/_types/summary";
+
+const SummaryDetail: React.FC = () => {
+  const params = useParams();
+  const { id } = params;
+  const { token, session } = useSupabaseSession();
+  const [summary, setSummary] = useState<SummaryDetails>();
+  const [isLoading, setLoading] = useState<boolean>(true);
+
+  useEffect(()=> {
+    if(!token) return;
+    
+    const fetchSummary = async() => {
+      try {
+        const res = await fetch(`/api/summaries/${id}`, {
+          headers: {
+            "Content-Type" : "application/json",
+            Authorization: token,
+          },
+        });
+
+        const { summary } = await res.json();
+        setSummary(summary);
+        console.log(summary)
+      } catch(error) {
+        console.log(error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchSummary();
+  }, [token]);
+
+  return(
+    <>
+    </>
+  )
+}
+export default SummaryDetail;

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -7,6 +7,8 @@ import { SummaryDetails } from "@/_types/summary";
 import PageLoading from "@/app/_components/PageLoading";
 import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
 import Link from "next/link";
+import EditRoundButton from "@/app/_components/EditRoundButton";
+import DeleteRoundButton from "@/app/_components/DeleteRoundButton";
 
 const SummaryDetail: React.FC = () => {
   const params = useParams();
@@ -44,6 +46,10 @@ const SummaryDetail: React.FC = () => {
       {(summary && !isLoading) ? (
       <div className="flex justify-center">
         <div className="max-w-64 my-20 flex flex-col">
+          <div className="flex justify-end gap-3 my-2">
+            <EditRoundButton />
+            <DeleteRoundButton />
+          </div>
           <div>
             <p className="text-sm px-1">
               {changeFromISOtoDate(summary.createdAt, "date")}

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -4,11 +4,13 @@ import React, { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import { SummaryDetails } from "@/_types/summary";
+import PageLoading from "@/app/_components/PageLoading";
+import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
 
 const SummaryDetail: React.FC = () => {
   const params = useParams();
   const { id } = params;
-  const { token, session } = useSupabaseSession();
+  const { token } = useSupabaseSession();
   const [summary, setSummary] = useState<SummaryDetails>();
   const [isLoading, setLoading] = useState<boolean>(true);
 
@@ -34,10 +36,71 @@ const SummaryDetail: React.FC = () => {
       }
     }
     fetchSummary();
-  }, [token]);
+  }, [token, id]);
 
   return(
     <>
+      {(summary && !isLoading) ? (
+      <div className="flex justify-center">
+        <div className="max-w-64 my-20 flex flex-col">
+          <div>
+            <p className="text-sm px-1">
+              {changeFromISOtoDate(summary.createdAt, "date")}
+            </p>
+            <h2 className="text-2xl border-b-2 border-gray-700 pb-2">
+              {summary.title}
+            </h2>
+          </div>
+
+          {/* 説明エリア */}
+          <p className="bg-white min-w-64 min-h-24 p-2 mt-6 mb-2 rounded-lg">
+            {summary.explanation}
+          </p>
+
+          {/* タグエリア */}
+          <div className="min-h-20">
+            {summary.summaryTags && summary.summaryTags.length > 0 && (
+              summary.summaryTags.map((tag) => (
+                <span 
+                  key={tag.tagId}
+                  className="mr-2 text-primary font-bold"
+                >
+                  {`#${tag.tag.name}`}
+                </span>
+              ))
+            )}
+          </div>
+
+          {/* 投稿一覧 */}
+          <div>
+            <h3 className="text-lg text-primary font-bold mb-1">
+              関連日記
+            </h3>
+            <ul className="flex flex-col gap-2">
+              {summary.diaries && summary.diaries.length > 0 ? (
+                summary.diaries.map((diary) => (
+                  <li
+                    key={diary.id}
+                    className="shadow-md border-rounded-lg p-2"
+                  >
+                    <p className="text-xs mx-1">
+                      {changeFromISOtoDate(diary.createdAt, "dateTime")}
+                    </p>
+                    <h3 className="text-xl">{diary.title}</h3>
+                  </li>
+                ))
+              ) : (
+                <li className="text-sm">
+                  このまとめに紐づく日記はありません
+                </li>
+              )}
+            </ul>
+          </div>
+        </div>
+      </div>
+      ) : (
+        <PageLoading />
+      )}
     </>
   )
 }

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -81,7 +81,7 @@ const SummaryDetail: React.FC = () => {
                 summary.diaries.map((diary) => (
                   <li
                     key={diary.id}
-                    className="shadow-md border-rounded-lg p-2"
+                    className="shadow-sm border border-primary rounded-lg p-2"
                   >
                     <p className="text-xs mx-1">
                       {changeFromISOtoDate(diary.createdAt, "dateTime")}

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -86,7 +86,7 @@ const SummaryDetail: React.FC = () => {
                     <p className="text-xs mx-1">
                       {changeFromISOtoDate(diary.createdAt, "dateTime")}
                     </p>
-                    <h3 className="text-xl">{diary.title}</h3>
+                    <h3 className="text-lg">{diary.title}</h3>
                   </li>
                 ))
               ) : (

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -29,7 +29,7 @@ const SummaryDetail: React.FC = () => {
 
         const { summary } = await res.json();
         setSummary(summary);
-        console.log(summary)
+
       } catch(error) {
         console.log(error);
       } finally {
@@ -59,7 +59,7 @@ const SummaryDetail: React.FC = () => {
           </p>
 
           {/* タグエリア */}
-          <div className="min-h-20">
+          <div>
             {summary.summaryTags && summary.summaryTags.length > 0 && (
               summary.summaryTags.map((tag) => (
                 <span 
@@ -73,7 +73,7 @@ const SummaryDetail: React.FC = () => {
           </div>
 
           {/* 投稿一覧 */}
-          <div>
+          <div className="mt-6">
             <h3 className="text-lg text-primary font-bold mb-1">
               関連日記
             </h3>

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import { SummaryDetails } from "@/_types/summary";
 import PageLoading from "@/app/_components/PageLoading";
 import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoDate";
+import Link from "next/link";
 
 const SummaryDetail: React.FC = () => {
   const params = useParams();
@@ -79,15 +80,16 @@ const SummaryDetail: React.FC = () => {
             <ul className="flex flex-col gap-2">
               {summary.diaries && summary.diaries.length > 0 ? (
                 summary.diaries.map((diary) => (
-                  <li
-                    key={diary.id}
-                    className="shadow-sm border border-primary rounded-lg p-2"
-                  >
-                    <p className="text-xs mx-1">
-                      {changeFromISOtoDate(diary.createdAt, "dateTime")}
-                    </p>
-                    <h3 className="text-lg">{diary.title}</h3>
-                  </li>
+                  <Link href={`/diaries/${diary.id}`} key={diary.id}>
+                    <li
+                      className="shadow-sm border border-primary rounded-lg p-2"
+                    >
+                      <p className="text-xs mx-1">
+                        {changeFromISOtoDate(diary.createdAt, "dateTime")}
+                      </p>
+                      <h3 className="text-lg">{diary.title}</h3>
+                    </li>
+                  </Link>
                 ))
               ) : (
                 <li className="text-sm">

--- a/src/app/summaries/page.tsx
+++ b/src/app/summaries/page.tsx
@@ -8,13 +8,13 @@ import SummaryForm from "./_components/SummaryForm";
 import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import InfiniteScroll from 'react-infinite-scroller';
 import LoadingDiary from "../diaries/_components/LoadingDiary";
-import { SummaryDetails } from "@/_types/summary";
+import { AllSummary } from "@/_types/summary";
 import PostUnit from "../_components/PostUnit";
 import summaryThumbnail from "@/public/summaryThumbnail.png";
 
 const SummaryIndex: React.FC = () => {
   const { token } = useSupabaseSession();
-  const [summaryList, setSummaryList] = useState<SummaryDetails[]>([]);
+  const [summaryList, setSummaryList] = useState<AllSummary[]>([]);
   const [hasMore, setHasMore] = useState(true);
   const [page, setPage] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
@@ -42,7 +42,7 @@ const SummaryIndex: React.FC = () => {
       const { summaries } = await res.json();
 
       setSummaryList((prevSummaryList) => {
-        const newSummaries = summaries.filter((newSummary: SummaryDetails) => !prevSummaryList.some((prevSummary) => prevSummary.id === newSummary.id));
+        const newSummaries = summaries.filter((newSummary: AllSummary) => !prevSummaryList.some((prevSummary) => prevSummary.id === newSummary.id));
 
         return [...prevSummaryList, ...newSummaries]
       });

--- a/src/app/utils/ChangeDateTime/changeFromISOtoDate.ts
+++ b/src/app/utils/ChangeDateTime/changeFromISOtoDate.ts
@@ -11,7 +11,7 @@ export const changeFromISOtoDate = (date: string, changeFormat: string) => {
   if (changeFormat === "dateTime") {
     formattedDate = format(zonedDate, 'yyyy/MM/dd HH:mm');
   } else if (changeFormat === "date") {
-    formattedDate = format(zonedDate, 'yyyy-MM-dd');
+    formattedDate = format(zonedDate, 'yyyy/MM/dd');
   } else {
     formattedDate = format(zonedDate, 'HH:mm');
   }


### PR DESCRIPTION
# why
ユーザーがまとめの詳細確認をできるようにするため。

# what
以下の実装を行いました。

- 一覧から該当のまとめをクリックする詳細ページに遷移する。
- 詳細ページでは、記録した日付、説明、タグ、関連日記が確認できる。
- まとめ投稿者の場合は、「編集」「削除」ボタンが画面上に表示される。