### PR TITLE
まとめ編集表示機能_フロント実装

### DIFF
--- a/src/app/api/summaries/[id]/route.ts
+++ b/src/app/api/summaries/[id]/route.ts
@@ -92,6 +92,15 @@ export const PUT = async(request: NextRequest, { params } : { params : Promise<{
         await Promise.all(updateTags);
       }
 
+      await tx.diary.updateMany({
+        where: {
+          summaryId: id,
+        },
+        data: {
+          summaryId: null
+        },
+      })
+
       if (diaryIds && diaryIds.length > 0) {
         const updateSummaries = diaryIds.map(async(id) => {
           const diary = await tx.diary.findUnique({

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -9,6 +9,8 @@ import { changeFromISOtoDate } from "@/app/utils/ChangeDateTime/changeFromISOtoD
 import Link from "next/link";
 import EditRoundButton from "@/app/_components/EditRoundButton";
 import DeleteRoundButton from "@/app/_components/DeleteRoundButton";
+import ModalWindow from "@/app/_components/ModalWindow";
+import SummaryForm from "../_components/SummaryForm";
 
 const SummaryDetail: React.FC = () => {
   const params = useParams();
@@ -16,6 +18,8 @@ const SummaryDetail: React.FC = () => {
   const { token } = useSupabaseSession();
   const [summary, setSummary] = useState<SummaryDetails>();
   const [isLoading, setLoading] = useState<boolean>(true);
+  const [openModal, setOpenModal] = useState(false);
+  const [refresh, setRefresh] = useState<boolean>(false);
 
   useEffect(()=> {
     if(!token) return;
@@ -31,7 +35,6 @@ const SummaryDetail: React.FC = () => {
 
         const { summary } = await res.json();
         setSummary(summary);
-
       } catch(error) {
         console.log(error);
       } finally {
@@ -41,15 +44,28 @@ const SummaryDetail: React.FC = () => {
     fetchSummary();
   }, [token, id]);
 
+  const ModalClose = () => {
+    setOpenModal(false);
+    setRefresh(!refresh);
+  }
+
+  const openEditModal = () => {
+    setOpenModal(true);
+  };
+
   return(
     <>
       {(summary && !isLoading) ? (
       <div className="flex justify-center">
         <div className="max-w-64 my-20 flex flex-col">
           <div className="flex justify-end gap-3 my-2">
-            <EditRoundButton />
+            <EditRoundButton EditClick={() => openEditModal()}/>
             <DeleteRoundButton />
+            <ModalWindow show={openModal} onClose={ModalClose}>
+              <SummaryForm summary={summary} isEdit={true} onClose={ModalClose} />
+            </ModalWindow>  
           </div>
+
           <div>
             <p className="text-sm px-1">
               {changeFromISOtoDate(summary.createdAt, "date")}

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -15,7 +15,7 @@ import SummaryForm from "../_components/SummaryForm";
 const SummaryDetail: React.FC = () => {
   const params = useParams();
   const { id } = params;
-  const { token } = useSupabaseSession();
+  const { token, session } = useSupabaseSession();
   const [summary, setSummary] = useState<SummaryDetails>();
   const [isLoading, setLoading] = useState<boolean>(true);
   const [openModal, setOpenModal] = useState(false);
@@ -59,11 +59,15 @@ const SummaryDetail: React.FC = () => {
       <div className="flex justify-center">
         <div className="max-w-64 my-20 flex flex-col">
           <div className="flex justify-end gap-3 my-2">
-            <EditRoundButton EditClick={() => openEditModal()}/>
-            <DeleteRoundButton />
-            <ModalWindow show={openModal} onClose={ModalClose}>
-              <SummaryForm summary={summary} isEdit={true} onClose={ModalClose} />
-            </ModalWindow>  
+            {session?.user.id === summary.ownerId && (
+              <>
+                <EditRoundButton EditClick={() => openEditModal()}/>
+                <DeleteRoundButton />
+                <ModalWindow show={openModal} onClose={ModalClose}>
+                  <SummaryForm summary={summary} isEdit={true} onClose={ModalClose} />
+                </ModalWindow>  
+              </>
+            )}
           </div>
 
           <div>

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -42,7 +42,7 @@ const SummaryDetail: React.FC = () => {
       }
     }
     fetchSummary();
-  }, [token, id]);
+  }, [token, id, refresh]);
 
   const ModalClose = () => {
     setOpenModal(false);

--- a/src/app/summaries/_components/SummaryForm.tsx
+++ b/src/app/summaries/_components/SummaryForm.tsx
@@ -37,18 +37,18 @@ const SummaryForm: React.FC<SummaryFormProps> = ({ onClose, summary, isEdit }) =
     try {
       if(!token) return;
 
-      const response = await fetch(`api/summaries`, {
+      const response = await fetch(isEdit ? `/api/summaries/${summary.id}` : "/api/summaries", {
         headers: {
           "Content-Type" : "application/json",
           Authorization: token,
         },
-        method: "POST",
+        method: isEdit ? "PUT" : "POST",
         body: JSON.stringify(req),
       });
 
       if(response.status === 200) {
         reset();
-        toast.success("投稿が完了しました");
+        toast.success(isEdit ? "更新しました" : "投稿が完了しました");
 
         setTimeout(() => {
           onClose();
@@ -56,7 +56,7 @@ const SummaryForm: React.FC<SummaryFormProps> = ({ onClose, summary, isEdit }) =
       }
     } catch (error) {
       console.log(error);
-      toast.error("投稿に失敗しました");
+      toast.error(isEdit ? "更新に失敗しました" : "投稿に失敗しました");
     }
   }
 
@@ -68,7 +68,7 @@ const SummaryForm: React.FC<SummaryFormProps> = ({ onClose, summary, isEdit }) =
     if(!token) return;
     const fetchDiaryList = async () => {
       try {
-        const response = await fetch(`api/users/${userId}/diaries`, {
+        const response = await fetch(`/api/users/${userId}/diaries`, {
           headers: {
             "Content-Type" : "application/json",
             Authorization: token,
@@ -101,7 +101,7 @@ const SummaryForm: React.FC<SummaryFormProps> = ({ onClose, summary, isEdit }) =
     <div className="flex justify-center">
       <form className="max-w-64 my-8" onSubmit={handleSubmit(onSubmit)}>
         <h2 className="text-primary text-center text-2xl font-bold mb-10">
-          まとめ投稿
+          {isEdit? "まとめ編集": "まとめ投稿"}
         </h2>
 
         <Input 
@@ -166,7 +166,7 @@ const SummaryForm: React.FC<SummaryFormProps> = ({ onClose, summary, isEdit }) =
 
         <LoadingButton 
           isSubmitting={isSubmitting}
-          buttonText={"登録"}
+          buttonText={isEdit ? "更新" : "登録"}
         />
       </form>
       <Toaster />

--- a/src/app/summaries/_components/SummaryForm.tsx
+++ b/src/app/summaries/_components/SummaryForm.tsx
@@ -13,8 +13,8 @@ import DiarySelection from "./DiarySelection";
 import { Option } from "../_types/Option";
 
 interface SummaryFormProps {
-  summary: SummaryDetails;
-  isEdit: boolean
+  summary?: SummaryDetails;
+  isEdit?: boolean
   onClose: () => void;
 }
 
@@ -23,7 +23,7 @@ const SummaryForm: React.FC<SummaryFormProps> = ({ onClose, summary, isEdit }) =
   const { token, session } = useSupabaseSession();
   const userId = session?.user.id;
   const {register, handleSubmit, reset, setValue, formState: {errors, isSubmitting}} = useForm<SummaryRequest>();
-  const initialSelectedDiaries = isEdit ? summary.diaries : [];
+  const initialSelectedDiaries = isEdit ? summary?.diaries : [];
   const [selectedDiaryIds, setSelectedDiaryIds] = useState<Option[]>(initialSelectedDiaries || []);
   const [diaryLists, setDiaryLists] = useState<Option[]>([]);
 
@@ -37,7 +37,7 @@ const SummaryForm: React.FC<SummaryFormProps> = ({ onClose, summary, isEdit }) =
     try {
       if(!token) return;
 
-      const response = await fetch(isEdit ? `/api/summaries/${summary.id}` : "/api/summaries", {
+      const response = await fetch(isEdit ? `/api/summaries/${summary?.id}` : "/api/summaries", {
         headers: {
           "Content-Type" : "application/json",
           Authorization: token,


### PR DESCRIPTION
# what
ユーザーが投稿済みの日記を編集できるようにするため。

# why
以下の実装を行いました。

- まとめの詳細ページで編集ボタンをクリックすると編集ページに遷移する。
- 編集ページでは既に投稿済みのデータが表示される。
- 情報を編集し、「更新」ボタンをクリックすると、データベースに編集した内容が保存される。
- 更新が完了したら、詳細ページに遷移する。
