### PR TITLE
まとめ削除機能_フロント実装

### DIFF
--- a/src/app/_components/ModalWindow.tsx
+++ b/src/app/_components/ModalWindow.tsx
@@ -18,7 +18,7 @@ const ModalWindow: React.FC<ModalProps> = ({ show, onClose, children }) => {
       popup
     >
     <Modal.Header className="bg-main"/>
-    <Modal.Body className="bg-main rounded-lg">
+    <Modal.Body className="bg-main rounded-b-lg">
       {children}
     </Modal.Body>
   </Modal>

--- a/src/app/_components/Tab.tsx
+++ b/src/app/_components/Tab.tsx
@@ -1,8 +1,21 @@
-import React, { useState }  from "react";
+"use client";
+
+import React, { useEffect, useState }  from "react";
+import { usePathname } from "next/navigation";
 import  Link  from "next/link";
 
 const Tab: React.FC = () => {
-  const [activeTab, setActiveTab] = useState("diaries");
+  const pathName = usePathname();
+  const [activeTab, setActiveTab] = useState<string>("");
+
+  useEffect(() => {
+    const path = pathName;
+    if(path.includes("/diaries")) {
+      setActiveTab("diaries");
+    } else if (path.includes("/summaries")) {
+      setActiveTab("summaries");
+    }
+  }, [pathName]);
 
   return(
   <div className="flex">

--- a/src/app/summaries/_components/DiarySelection.tsx
+++ b/src/app/summaries/_components/DiarySelection.tsx
@@ -12,7 +12,7 @@ const DiarySelection: React.FC<OptionProps<Option>> = (props) => {
         checked={props.isSelected}
         className="m-2 rounded-full border border-primary"
       />
-      <label htmlFor={props.data.id}>
+      <label htmlFor={props.data.id} className="text-primary">
         {props.data.title}
       </label>
     </div>

--- a/src/app/summaries/_components/SummaryForm.tsx
+++ b/src/app/summaries/_components/SummaryForm.tsx
@@ -142,6 +142,7 @@ const SummaryForm: React.FC<SummaryFormProps> = ({ onClose, summary, isEdit }) =
             getOptionLabel={(option) => option.title}
             getOptionValue={(option) => option.id}
             closeMenuOnSelect={false}
+            blurInputOnSelect={false}
             isMulti
             components={{Option: DiarySelection }}
             styles={{


### PR DESCRIPTION
# why
ユーザーが投稿済みのまとめ記録を削除できるようにするため。

# what
以下の実装を行いました。

- まとめ詳細ページで削除ボタンをクリックすると削除確認用のダイアログが表示される。
- ダイアログ上でキャンセルボタンをクリックすると、ダイアログが閉じる。
- ダイアログ上で削除ボタンをクリックすると、データベース上からまとめを削除する。
- 削除が完了したら、まとめ一覧ページに遷移する。
- 削除した投稿はまとめ一覧ページからも削除される。
- タブ選択の背景色がまとめ選択をしていても、変更されないバグの修正を実施。