### PR TITLE
コメント登録機能_フロント実装

### DIFF
--- a/src/app/_components/LoadingButton.tsx
+++ b/src/app/_components/LoadingButton.tsx
@@ -9,7 +9,7 @@ interface LoadingButtonProps {
 
 const LoadingButton: React.FC<LoadingButtonProps> = ({isSubmitting, buttonText}) => {
   return(
-    <div className="flex items-center justify-center mt-10">
+    <div className="flex items-center justify-center mt-8">
       {isSubmitting ? (
         <button disabled type="button" className="rounded-full text-white bg-primary focus:ring-4 focus:ring-blue-300 font-medium text-sm px-5 py-2.5 text-center me-2 inline-flex items-center">
           <svg aria-hidden="true" role="status" className="inline w-4 h-4 me-3 text-white animate-spin" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/app/cares/[id]/page.tsx
+++ b/src/app/cares/[id]/page.tsx
@@ -42,6 +42,7 @@ const CareDetail: React.FC = () => {
   const [openModal, setOpenModal] = useState(false);
   const [refresh, setRefresh] = useState<boolean>(false);
   const [isEditMode, setIsEditMode] = useState(false);
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
 
   useEffect(() => {
     if (!token) return;
@@ -85,6 +86,7 @@ const CareDetail: React.FC = () => {
 
   const handleDelete = async () => {
     if(!token || currentUserId !== care?.ownerId) return;
+    setIsDeleting(true);
 
     try {
       const response = await fetch(`/api/cares/${id}`, {
@@ -109,6 +111,8 @@ const CareDetail: React.FC = () => {
     } catch(error) {
       console.log(error);
       toast.error("削除に失敗しました");
+    } finally {
+      setIsDeleting(false);
     }
   }
  
@@ -188,7 +192,7 @@ const CareDetail: React.FC = () => {
             {isEditMode ? (
               <CareForm careId={care.careListId} careName={care.careList.name} token={token} onClose={ModalClose} isEdit={true} careInfo={care}/>
             ) : (
-              <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="お世話記録"/>
+              <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="お世話記録" isDeleting={isDeleting} />
             )}
           </ModalWindow>
         </div>

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -16,6 +16,7 @@ import DeleteAlert from "@/app/_components/DeleteAlert";
 import deleteStorageImage from "@/app/utils/deleteStorageImage";
 import EditRoundButton from "@/app/_components/EditRoundButton";
 import DeleteRoundButton from "@/app/_components/DeleteRoundButton";
+import CommentForm from "../_components/CommentForm";
 
 const DiaryDetail: React.FC = () => {
   const params = useParams();
@@ -158,24 +159,24 @@ const DiaryDetail: React.FC = () => {
             </div>
     
             <div className="flex my-8 text-primary">
-              <div 
+              <button 
                 className="w-1/2 p-2 text-center border border-primary solid rounded flex items-center justify-center gap-1"
                 onClick={() => openCommentModal()}
               >
                 <span className="i-mdi-chat-processing-outline"></span>
                 <span className="text-sm">コメントする</span>
-              </div>
-              <div className="w-1/2 p-2 text-center border border-primary solid rounded flex items-center justify-center gap-1">
+              </button>
+              <button className="w-1/2 p-2 text-center border border-primary solid rounded flex items-center justify-center gap-1">
                 <span className="i-material-symbols-bookmark-add-outline"></span>
                 <span className="text-sm">ブックマーク</span>
-              </div>
+              </button>
             </div>
           </div>
           <ModalWindow show={openModal} onClose={ModalClose} >
             <>
               {modalType === "edit" && <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />}
               {modalType === "delete" && <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="日記" isDeleting={isDeleting}/>}
-              {modalType === "comment" && <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />}
+              {modalType === "comment" && <CommentForm  />}
             </>
           </ModalWindow>
         </div>

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -28,23 +28,29 @@ const DiaryDetail: React.FC = () => {
   const [openModal, setOpenModal] = useState(false);
   const [refresh, setRefresh] = useState<boolean>(false);
   const [isLoading, setLoading] = useState<boolean>(true);
-  const [isEditMode, setIsEditMode] = useState(false);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
+  const [modalType, setModalType] = useState<string>("");
 
   const ModalClose = () => {
     setOpenModal(false);
     setRefresh(!refresh);
+    setModalType("");
   }
 
   const openEditModal = () => {
-    setIsEditMode(true);
+    setModalType("edit");
     setOpenModal(true);
   };
 
   const openDeleteModal = () => {
-    setIsEditMode(false);
+    setModalType("delete");
     setOpenModal(true);
   };
+
+  const openCommentModal = () => {
+    setModalType("comment");
+    setOpenModal(true);
+  }
 
   const handleDelete = async () => {
     if(!token || currentUserId !== diary?.ownerId) return;
@@ -114,14 +120,6 @@ const DiaryDetail: React.FC = () => {
                   <DeleteRoundButton DeleteClick={() => openDeleteModal()}/>
                 </>
               )}
-              <ModalWindow show={openModal} onClose={ModalClose} >
-                {isEditMode ? (
-                  <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />
-                ): (
-                  <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="日記" isDeleting={isDeleting}/>
-                ) 
-                }
-              </ModalWindow>
             </div>
 
             <div className="mb-6 text-gray-800">
@@ -159,18 +157,27 @@ const DiaryDetail: React.FC = () => {
               )}
             </div>
     
-            <div className="flex my-8">
-              <div className="w-1/2 p-2 text-center border border-primary solid rounded bg-primary text-white flex items-center justify-center gap-1">
+            <div className="flex my-8 text-primary">
+              <div 
+                className="w-1/2 p-2 text-center border border-primary solid rounded flex items-center justify-center gap-1"
+                onClick={() => openCommentModal()}
+              >
                 <span className="i-mdi-chat-processing-outline"></span>
                 <span className="text-sm">コメントする</span>
               </div>
-              <div className="w-1/2 p-2 text-center border border-primary solid rounded flex items-center justify-center gap-1 text-gray-800">
+              <div className="w-1/2 p-2 text-center border border-primary solid rounded flex items-center justify-center gap-1">
                 <span className="i-material-symbols-bookmark-add-outline"></span>
                 <span className="text-sm">ブックマーク</span>
               </div>
             </div>
-    
           </div>
+          <ModalWindow show={openModal} onClose={ModalClose} >
+            <>
+              {modalType === "edit" && <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />}
+              {modalType === "delete" && <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="日記" isDeleting={isDeleting}/>}
+              {modalType === "comment" && <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />}
+            </>
+          </ModalWindow>
         </div>
       ) : (
         <PageLoading />

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -176,7 +176,7 @@ const DiaryDetail: React.FC = () => {
             <>
               {modalType === "edit" && <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />}
               {modalType === "delete" && <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="日記" isDeleting={isDeleting}/>}
-              {modalType === "comment" && <CommentForm  />}
+              {modalType === "comment" && <CommentForm diary={diary} />}
             </>
           </ModalWindow>
         </div>

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -176,7 +176,7 @@ const DiaryDetail: React.FC = () => {
             <>
               {modalType === "edit" && <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />}
               {modalType === "delete" && <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="日記" isDeleting={isDeleting}/>}
-              {modalType === "comment" && <CommentForm diary={diary} />}
+              {modalType === "comment" && <CommentForm diary={diary} onClose={ModalClose}/>}
             </>
           </ModalWindow>
         </div>

--- a/src/app/diaries/_components/CommentForm.tsx
+++ b/src/app/diaries/_components/CommentForm.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+const CommentForm:React.FC = () => {
+  return(
+    <>
+      <h1>コメント</h1>
+      <form action="">
+
+      </form>
+    </>
+
+  )
+}
+export default CommentForm;

--- a/src/app/diaries/_components/CommentForm.tsx
+++ b/src/app/diaries/_components/CommentForm.tsx
@@ -1,13 +1,67 @@
 import React from "react";
-const CommentForm:React.FC = () => {
+import Textarea from "@/app/_components/Textarea";
+import { useRouteGuard } from "@/_hooks/useRouteGuard";
+import { useForm, SubmitHandler } from "react-hook-form";
+import LoadingButton from "@/app/_components/LoadingButton";
+import { Comment } from "@/_types/comment";
+import { DiaryDetails } from "@/_types/diary";
+import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
+import toast from "react-hot-toast";
+
+interface CommentProps {
+  diary: DiaryDetails;
+}
+
+const CommentForm:React.FC<CommentProps> = ({ diary }) => {
+  useRouteGuard();
+  const { token } = useSupabaseSession();
+  const diaryId = diary.id;
+  const { register, handleSubmit, reset, formState: { errors, isSubmitting }} = useForm<Comment>();
+
+  const onSubmit: SubmitHandler<Comment> = async(data) => {
+    const req = {
+      ...data,
+      diaryId
+    }
+
+    if(!token) return;
+    try {
+      const response = await fetch(`/api/diaries/${diaryId}/comments`, {
+        headers: {
+          "Content-Type" : "application/json",
+          Authorization: token,
+        },
+        method: "POST",
+        body: JSON.stringify(req),
+      });
+
+      if(response.status === 200) {
+        reset();
+        toast.success("コメントを投稿しました");
+      }
+    } catch(error) {
+      console.log(error);
+      toast.error("コメント投稿に失敗しました");
+    }
+  }
+
   return(
-    <>
-      <h1>コメント</h1>
-      <form action="">
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Textarea 
+        id="comment"
+        labelName=""
+        placeholder="コメントを書く"
+        register={{...register("comment", {
+          required: "コメントは必須です。"
+        })}}
+        error={errors.comment?.message}
+      />
 
-      </form>
-    </>
-
+      <LoadingButton 
+        isSubmitting={isSubmitting}
+        buttonText="投稿"
+      />
+    </form>
   )
 }
 export default CommentForm;

--- a/src/app/diaries/_components/CommentForm.tsx
+++ b/src/app/diaries/_components/CommentForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React  from "react";
 import Textarea from "@/app/_components/Textarea";
 import { useRouteGuard } from "@/_hooks/useRouteGuard";
 import { useForm, SubmitHandler } from "react-hook-form";
@@ -10,9 +10,10 @@ import toast from "react-hot-toast";
 
 interface CommentProps {
   diary: DiaryDetails;
+  onClose: () => void;
 }
 
-const CommentForm:React.FC<CommentProps> = ({ diary }) => {
+const CommentForm:React.FC<CommentProps> = ({ diary, onClose }) => {
   useRouteGuard();
   const { token } = useSupabaseSession();
   const diaryId = diary.id;
@@ -38,11 +39,16 @@ const CommentForm:React.FC<CommentProps> = ({ diary }) => {
       if(response.status === 200) {
         reset();
         toast.success("コメントを投稿しました");
-      }
+
+        setTimeout(() => {
+          onClose();
+        }, 2000);
+      };
+
     } catch(error) {
       console.log(error);
       toast.error("コメント投稿に失敗しました");
-    }
+    } 
   }
 
   return(

--- a/src/app/utils/ChangeDateTime/changeFromISOtoDate.ts
+++ b/src/app/utils/ChangeDateTime/changeFromISOtoDate.ts
@@ -11,7 +11,7 @@ export const changeFromISOtoDate = (date: string, changeFormat: string) => {
   if (changeFormat === "dateTime") {
     formattedDate = format(zonedDate, 'yyyy/MM/dd HH:mm');
   } else if (changeFormat === "date") {
-    formattedDate = format(zonedDate, 'yyyy/MM/dd');
+    formattedDate = format(zonedDate, 'yyyy-MM-dd');
   } else {
     formattedDate = format(zonedDate, 'HH:mm');
   }


### PR DESCRIPTION
# what
ユーザーが日記に対してコメントを投稿できるようにするため。

# why
以下の実装を行いました。

- 日記詳細ページで「コメントする」ボタンをクリックすると、コメント登録用のモーダルが表示される。
- コメントを記入して登録ボタンをクリックすると、データベースに「コメント内容」「日記のID」「投稿者のID」が登録される。
- コメント投稿が成功したら投稿完了のポップアップが表示され、モーダルが閉じる
- コメント投稿が失敗したら、投稿が失敗した旨のポップアップが表示される。