### PR TITLE
コメント一覧表示機能_フロント実装

### DIFF
--- a/src/_types/comment.ts
+++ b/src/_types/comment.ts
@@ -1,3 +1,13 @@
 export interface Comment{
   comment: string
 }
+
+export interface CommentProps {
+  id: string;
+  comment: string;
+  owner: { nickname: string };
+}
+
+export interface CommentsProps {
+  comments: CommentProps[];
+}

--- a/src/_types/comment.ts
+++ b/src/_types/comment.ts
@@ -5,7 +5,7 @@ export interface Comment{
 export interface CommentProps {
   id: string;
   comment: string;
-  owner: { nickname: string };
+  owner: { id: string, nickname: string };
 }
 
 export interface CommentsProps {

--- a/src/_types/diary.ts
+++ b/src/_types/diary.ts
@@ -1,4 +1,5 @@
 import { Tag } from "@/_types/tag";
+import { CommentProps } from "./comment";
 
 export interface DiaryRequest {
   title: string;
@@ -21,5 +22,5 @@ export interface BaseDiary {
 
 export interface DiaryDetails extends BaseDiary {
   ownerId: string;
-  comments: {comment: string, nickname: string}
+  comments: CommentProps[];
 }

--- a/src/app/_components/DeleteRoundButton.tsx
+++ b/src/app/_components/DeleteRoundButton.tsx
@@ -2,16 +2,18 @@ import React from "react";
 
 interface DeleteButtonProps {
   DeleteClick?: () => void;
+  width: string;
+  height: string;
 }
 
-const DeleteRoundButton: React.FC<DeleteButtonProps> = ({DeleteClick}) => {
+const DeleteRoundButton: React.FC<DeleteButtonProps> = ({DeleteClick, width, height}) => {
   return(
   <div>
     <button 
       className="flex items-center justify-center rounded-full bg-gray-300 p-2"
       onClick={DeleteClick}
       >
-      <span className="i-material-symbols-light-delete-outline w-8 h-8"></span>
+      <span className={`i-material-symbols-light-delete-outline ${width} ${height}`}></span>
     </button>
   </div>
   )

--- a/src/app/_components/EditRoundButton.tsx
+++ b/src/app/_components/EditRoundButton.tsx
@@ -2,16 +2,18 @@ import React from "react";
 
 interface EditButtonProps {
   EditClick?: () => void;
+  width: string;
+  height: string;
 }
 
-const EditRoundButton: React.FC<EditButtonProps> = ({EditClick}) => {
+const EditRoundButton: React.FC<EditButtonProps> = ({EditClick, width, height}) => {
   return(
   <div>
     <button 
       className="flex items-center justify-center rounded-full bg-secondary p-2"
       onClick={EditClick}
       >
-      <span  className="i-material-symbols-light-edit-square-outline w-8 h-8"></span>
+      <span  className={`i-material-symbols-light-edit-square-outline ${width} ${height}`}></span>
     </button>
   </div>
   )

--- a/src/app/api/diaries/[id]/route.ts
+++ b/src/app/api/diaries/[id]/route.ts
@@ -28,6 +28,7 @@ export const GET = async(request:NextRequest, { params } : { params: Promise<{id
         },
         comments: {
           select: {
+            id: true,
             comment: true,
             owner: {
               select: {

--- a/src/app/api/diaries/[id]/route.ts
+++ b/src/app/api/diaries/[id]/route.ts
@@ -32,6 +32,7 @@ export const GET = async(request:NextRequest, { params } : { params: Promise<{id
             comment: true,
             owner: {
               select: {
+                id: true,
                 nickname: true
               },
             },

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -17,6 +17,7 @@ import deleteStorageImage from "@/app/utils/deleteStorageImage";
 import EditRoundButton from "@/app/_components/EditRoundButton";
 import DeleteRoundButton from "@/app/_components/DeleteRoundButton";
 import CommentForm from "../_components/CommentForm";
+import CommentList from "../_components/CommentList";
 
 const DiaryDetail: React.FC = () => {
   const params = useParams();
@@ -117,8 +118,8 @@ const DiaryDetail: React.FC = () => {
             <div className="flex justify-end gap-3 my-2">
               {session?.user.id === diary.ownerId && (
                 <>
-                  <EditRoundButton EditClick={() => openEditModal()}/>
-                  <DeleteRoundButton DeleteClick={() => openDeleteModal()}/>
+                  <EditRoundButton EditClick={() => openEditModal()} width="w-8" height="h-8"/>
+                  <DeleteRoundButton DeleteClick={() => openDeleteModal()} width="w-8" height="h-8"/>
                 </>
               )}
             </div>
@@ -171,7 +172,13 @@ const DiaryDetail: React.FC = () => {
                 <span className="text-sm">ブックマーク</span>
               </button>
             </div>
+            
+            {/* コメント一覧表示 */}
+            <div>
+              <CommentList />
+            </div>
           </div>
+          {/* モーダル表示エリア */}
           <ModalWindow show={openModal} onClose={ModalClose} >
             <>
               {modalType === "edit" && <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />}

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -101,7 +101,6 @@ const DiaryDetail: React.FC = () => {
 
         const { diary } = await res.json();
         setDiary(diary);
-        console.log(diary)
       } catch(error) {
         console.log(error);
       } finally {
@@ -176,7 +175,7 @@ const DiaryDetail: React.FC = () => {
             
             {/* コメント一覧表示 */}
             <div>
-              <CommentList comments={diary.comments}/>
+              <CommentList comments={diary.comments} currentUserId={currentUserId}/>
             </div>
           </div>
           {/* モーダル表示エリア */}

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -101,6 +101,7 @@ const DiaryDetail: React.FC = () => {
 
         const { diary } = await res.json();
         setDiary(diary);
+        console.log(diary)
       } catch(error) {
         console.log(error);
       } finally {
@@ -175,7 +176,7 @@ const DiaryDetail: React.FC = () => {
             
             {/* コメント一覧表示 */}
             <div>
-              <CommentList />
+              <CommentList comments={diary.comments}/>
             </div>
           </div>
           {/* モーダル表示エリア */}

--- a/src/app/diaries/_components/CommentList.tsx
+++ b/src/app/diaries/_components/CommentList.tsx
@@ -3,12 +3,16 @@ import EditRoundButton from "@/app/_components/EditRoundButton";
 import React from "react";
 import { CommentsProps } from "@/_types/comment";
 
-const CommentList: React.FC<CommentsProps> = ({comments}) => {
+interface CommentIndexProps extends CommentsProps {
+  currentUserId?: string;
+}
+
+const CommentList: React.FC<CommentIndexProps> = ({ comments, currentUserId }) => {
   return(
     <>
-    <ul>
+    <ul className="flex flex-col gap-2">
       {comments.map((comment) => (
-        <li className="border-b border-gray-800" key={comment.id}>
+        <li className="shadow-lg rounded-lg p-2" key={comment.id}>
           <div className="flex justify-between items-center">
             <div className="flex items-center gap-1">
               <span className="rounded-full bg-primary text-white px-1">
@@ -17,10 +21,12 @@ const CommentList: React.FC<CommentsProps> = ({comments}) => {
               <span className="text-xs font-bold">{comment.owner.nickname}</span>
             </div>
 
-            <div className="flex gap-2">
-              <EditRoundButton width="w-4" height="h-4" />
-              <DeleteRoundButton width="w-4" height="h-4" />
-            </div>
+            {comment.owner.id === currentUserId && (
+              <div className="flex gap-2">
+                <EditRoundButton width="w-4" height="h-4" />
+                <DeleteRoundButton width="w-4" height="h-4" />
+              </div>
+            )}
           </div>
           <p className="py-0.5">{comment.comment}</p>
         </li>

--- a/src/app/diaries/_components/CommentList.tsx
+++ b/src/app/diaries/_components/CommentList.tsx
@@ -2,27 +2,38 @@ import DeleteRoundButton from "@/app/_components/DeleteRoundButton";
 import EditRoundButton from "@/app/_components/EditRoundButton";
 import React from "react";
 
-const CommentList: React.FC = () => {
+interface CommentProps {
+  id: string;
+  comment: string;
+  owner: { nickname: string };
+}
+
+interface CommentsProps {
+  comments: CommentProps[];
+}
+
+const CommentList: React.FC<CommentsProps> = ({comments}) => {
   return(
     <>
     <ul>
-      <li className="border-b border-gray-800">
-        <div className="flex justify-between items-center">
-          <div className="flex items-center gap-1">
-            <span className="rounded-full bg-primary text-white px-1">
-              <span className="i-material-symbols-sound-detection-dog-barking-outline w-4 h-4"></span>
-            </span>
-            <span className="text-xs font-bold">userName</span>
-          </div>
+      {comments.map((comment) => (
+        <li className="border-b border-gray-800" key={comment.id}>
+          <div className="flex justify-between items-center">
+            <div className="flex items-center gap-1">
+              <span className="rounded-full bg-primary text-white px-1">
+                <span className="i-material-symbols-sound-detection-dog-barking-outline w-4 h-4"></span>
+              </span>
+              <span className="text-xs font-bold">{comment.owner.nickname}</span>
+            </div>
 
-          {/* buttonエリア */}
-          <div className="flex gap-2">
-            <EditRoundButton width="w-4" height="h-4" />
-            <DeleteRoundButton width="w-4" height="h-4" />
+            <div className="flex gap-2">
+              <EditRoundButton width="w-4" height="h-4" />
+              <DeleteRoundButton width="w-4" height="h-4" />
+            </div>
           </div>
-        </div>
-        <p>コンテンツ</p>
-      </li>
+          <p className="py-0.5">{comment.comment}</p>
+        </li>
+      ))}
     </ul>
     </>
   )

--- a/src/app/diaries/_components/CommentList.tsx
+++ b/src/app/diaries/_components/CommentList.tsx
@@ -1,16 +1,7 @@
 import DeleteRoundButton from "@/app/_components/DeleteRoundButton";
 import EditRoundButton from "@/app/_components/EditRoundButton";
 import React from "react";
-
-interface CommentProps {
-  id: string;
-  comment: string;
-  owner: { nickname: string };
-}
-
-interface CommentsProps {
-  comments: CommentProps[];
-}
+import { CommentsProps } from "@/_types/comment";
 
 const CommentList: React.FC<CommentsProps> = ({comments}) => {
   return(

--- a/src/app/diaries/_components/CommentList.tsx
+++ b/src/app/diaries/_components/CommentList.tsx
@@ -1,0 +1,31 @@
+import DeleteRoundButton from "@/app/_components/DeleteRoundButton";
+import EditRoundButton from "@/app/_components/EditRoundButton";
+import React from "react";
+
+const CommentList: React.FC = () => {
+  return(
+    <>
+    <ul>
+      <li className="border-b border-gray-800">
+        <div className="flex justify-between items-center">
+          <div className="flex items-center gap-1">
+            <span className="rounded-full bg-primary text-white px-1">
+              <span className="i-material-symbols-sound-detection-dog-barking-outline w-4 h-4"></span>
+            </span>
+            <span className="text-xs font-bold">userName</span>
+          </div>
+
+          {/* buttonエリア */}
+          <div className="flex gap-2">
+            <EditRoundButton width="w-4" height="h-4" />
+            <DeleteRoundButton width="w-4" height="h-4" />
+          </div>
+        </div>
+        <p>コンテンツ</p>
+      </li>
+    </ul>
+    </>
+  )
+}
+export default CommentList;
+

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -102,8 +102,8 @@ const SummaryDetail: React.FC = () => {
           <div className="flex justify-end gap-3 my-2">
             {session?.user.id === summary.ownerId && (
               <>
-                <EditRoundButton EditClick={() => openEditModal()}/>
-                <DeleteRoundButton DeleteClick={() => openDeleteModal()}/>
+                <EditRoundButton EditClick={() => openEditModal()} width="w-8" height="h-8"/>
+                <DeleteRoundButton DeleteClick={() => openDeleteModal()} width="w-8" height="h-8"/>
               </>
               )}
               <ModalWindow show={openModal} onClose={ModalClose}>


### PR DESCRIPTION
# why
ユーザーが日記に対してコメント投稿できるようにするため。

# what
以下の実装を行いました。

- 記事詳細ページを開くと、紐づいたコメント一覧が表示される。
- コメント一覧表示では「投稿者名」「コメント内容」が確認できる。
- コメント投稿者の場合は、編集・削除ボタンが表示される。