### PR TITLE
コメント編集機能_フロント実装

### DIFF
--- a/src/app/_components/DeleteRoundButton.tsx
+++ b/src/app/_components/DeleteRoundButton.tsx
@@ -10,7 +10,7 @@ const DeleteRoundButton: React.FC<DeleteButtonProps> = ({DeleteClick, width, hei
   return(
   <div>
     <button 
-      className="flex items-center justify-center rounded-full bg-gray-300 p-2"
+      className="flex items-center justify-center rounded-full bg-gray-300 p-2 drop-shadow-lg"
       onClick={DeleteClick}
       >
       <span className={`i-material-symbols-light-delete-outline ${width} ${height}`}></span>

--- a/src/app/_components/EditRoundButton.tsx
+++ b/src/app/_components/EditRoundButton.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 
 interface EditButtonProps {
-  EditClick?: () => void;
+  editClick?: () => void;
   width: string;
   height: string;
 }
 
-const EditRoundButton: React.FC<EditButtonProps> = ({EditClick, width, height}) => {
+const EditRoundButton: React.FC<EditButtonProps> = ({editClick, width, height}) => {
   return(
   <div>
     <button 
       className="flex items-center justify-center rounded-full bg-secondary p-2"
-      onClick={EditClick}
+      onClick={editClick}
       >
       <span  className={`i-material-symbols-light-edit-square-outline ${width} ${height}`}></span>
     </button>

--- a/src/app/_components/EditRoundButton.tsx
+++ b/src/app/_components/EditRoundButton.tsx
@@ -10,7 +10,7 @@ const EditRoundButton: React.FC<EditButtonProps> = ({editClick, width, height}) 
   return(
   <div>
     <button 
-      className="flex items-center justify-center rounded-full bg-secondary p-2"
+      className="flex items-center justify-center rounded-full bg-secondary p-2 drop-shadow-lg"
       onClick={editClick}
       >
       <span  className={`i-material-symbols-light-edit-square-outline ${width} ${height}`}></span>

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -54,6 +54,10 @@ const DiaryDetail: React.FC = () => {
     setOpenModal(true);
   }
 
+  const refreshComments = () => {
+    setRefresh(!refresh);
+  }
+
   const handleDelete = async () => {
     if(!token || currentUserId !== diary?.ownerId) return;
 
@@ -175,7 +179,7 @@ const DiaryDetail: React.FC = () => {
             
             {/* コメント一覧表示 */}
             <div>
-              <CommentList comments={diary.comments} currentUserId={currentUserId}/>
+              <CommentList comments={diary.comments} diary={diary} currentUserId={currentUserId} refreshComments={refreshComments}/>
             </div>
           </div>
           {/* モーダル表示エリア */}
@@ -183,7 +187,7 @@ const DiaryDetail: React.FC = () => {
             <>
               {modalType === "edit" && <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />}
               {modalType === "delete" && <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="日記" isDeleting={isDeleting}/>}
-              {modalType === "comment" && <CommentForm diary={diary} onClose={ModalClose}/>}
+              {modalType === "comment" && <CommentForm diary={diary} onClose={ModalClose} isEdit={false} comment={null} />}
             </>
           </ModalWindow>
         </div>

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -118,7 +118,7 @@ const DiaryDetail: React.FC = () => {
             <div className="flex justify-end gap-3 my-2">
               {session?.user.id === diary.ownerId && (
                 <>
-                  <EditRoundButton EditClick={() => openEditModal()} width="w-8" height="h-8"/>
+                  <EditRoundButton editClick={() => openEditModal()} width="w-8" height="h-8"/>
                   <DeleteRoundButton DeleteClick={() => openDeleteModal()} width="w-8" height="h-8"/>
                 </>
               )}

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -187,7 +187,7 @@ const DiaryDetail: React.FC = () => {
             <>
               {modalType === "edit" && <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />}
               {modalType === "delete" && <DeleteAlert onDelete={handleDelete} onClose={ModalClose} deleteObj="日記" isDeleting={isDeleting}/>}
-              {modalType === "comment" && <CommentForm diary={diary} onClose={ModalClose} isEdit={false} comment={null} />}
+              {modalType === "comment" && <CommentForm diary={diary} onClose={ModalClose} isEdit={false} selectedComment={null} />}
             </>
           </ModalWindow>
         </div>

--- a/src/app/diaries/_components/CommentForm.tsx
+++ b/src/app/diaries/_components/CommentForm.tsx
@@ -12,10 +12,10 @@ interface CommentFormProps {
   diary: DiaryDetails;
   onClose: () => void;
   isEdit: boolean;
-  comment: CommentProps | null;
+  selectedComment: CommentProps | null;
 }
 
-const CommentForm:React.FC<CommentFormProps> = ({ diary, onClose, isEdit, comment }) => {
+const CommentForm:React.FC<CommentFormProps> = ({ diary, onClose, isEdit, selectedComment }) => {
   useRouteGuard();
   const { token } = useSupabaseSession();
   const diaryId = diary.id;
@@ -29,7 +29,7 @@ const CommentForm:React.FC<CommentFormProps> = ({ diary, onClose, isEdit, commen
 
     if(!token) return;
     try {
-      const response = await fetch(isEdit ? `/api/diaries/${diaryId}/comments/${comment?.id}` : `/api/diaries/${diaryId}/comments`, {
+      const response = await fetch(isEdit ? `/api/diaries/${diaryId}/comments/${selectedComment?.id}` : `/api/diaries/${diaryId}/comments`, {
         headers: {
           "Content-Type" : "application/json",
           Authorization: token,
@@ -54,10 +54,10 @@ const CommentForm:React.FC<CommentFormProps> = ({ diary, onClose, isEdit, commen
   }
 
   useEffect(() => {
-    if(isEdit && comment) {
-      setValue("comment", comment.comment)
+    if(isEdit && selectedComment) {
+      setValue("comment", selectedComment.comment)
     }
-  }, [isEdit, setValue, comment]);
+  }, [isEdit, setValue, selectedComment]);
 
   return(
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/app/diaries/_components/CommentList.tsx
+++ b/src/app/diaries/_components/CommentList.tsx
@@ -1,6 +1,6 @@
 import DeleteRoundButton from "@/app/_components/DeleteRoundButton";
 import EditRoundButton from "@/app/_components/EditRoundButton";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { CommentProps, CommentsProps } from "@/_types/comment";
 import CommentForm from "./CommentForm";
 import ModalWindow from "@/app/_components/ModalWindow";

--- a/src/app/diaries/_components/CommentList.tsx
+++ b/src/app/diaries/_components/CommentList.tsx
@@ -1,36 +1,61 @@
 import DeleteRoundButton from "@/app/_components/DeleteRoundButton";
 import EditRoundButton from "@/app/_components/EditRoundButton";
-import React from "react";
-import { CommentsProps } from "@/_types/comment";
+import React, { useEffect, useState } from "react";
+import { CommentProps, CommentsProps } from "@/_types/comment";
+import CommentForm from "./CommentForm";
+import ModalWindow from "@/app/_components/ModalWindow";
+import { DiaryDetails } from "@/_types/diary";
 
 interface CommentIndexProps extends CommentsProps {
   currentUserId?: string;
+  diary: DiaryDetails;
+  refreshComments: () => void;
 }
 
-const CommentList: React.FC<CommentIndexProps> = ({ comments, currentUserId }) => {
+const CommentList: React.FC<CommentIndexProps> = ({ comments, currentUserId, diary, refreshComments }) => {
+  const [openModal, setOpenModal] = useState<boolean>(false);
+  const [selectedComment, setSelectedComment] = useState<CommentProps | null>(null);
+  const [refresh, setRefresh] = useState<boolean>(false);
+
+  const openEditCommentModal = (comment: CommentProps) => {
+    setSelectedComment(comment)
+    setOpenModal(true);
+  }
+
+  const CloseEditCommentModal = () => {
+    setOpenModal(false);
+    setSelectedComment(null);
+    refreshComments();
+  }
+
   return(
     <>
     <ul className="flex flex-col gap-2">
       {comments && comments.map((comment) => (
-        <li className="shadow-lg rounded-lg p-2" key={comment.id}>
-          <div className="flex justify-between items-center">
-            <div className="flex items-center gap-1">
-              <span className="rounded-full bg-primary text-white px-1">
-                <span className="i-material-symbols-sound-detection-dog-barking-outline w-4 h-4"></span>
-              </span>
-              <span className="text-xs font-bold">{comment.owner.nickname}</span>
-            </div>
-
-            {comment.owner.id === currentUserId && (
-              <div className="flex gap-2">
-                <EditRoundButton width="w-4" height="h-4" />
-                <DeleteRoundButton width="w-4" height="h-4" />
+          <li className="shadow-lg rounded-lg p-2" key={comment.id}>
+            <div className="flex justify-between items-center">
+              <div className="flex items-center gap-1">
+                <span className="rounded-full bg-primary text-white px-1">
+                  <span className="i-material-symbols-sound-detection-dog-barking-outline w-4 h-4"></span>
+                </span>
+                <span className="text-xs font-bold">{comment.owner.nickname}</span>
               </div>
-            )}
-          </div>
-          <p className="py-0.5">{comment.comment}</p>
-        </li>
+
+              {comment.owner.id === currentUserId && (
+                <div className="flex gap-2">
+                  <div onClick={() => openEditCommentModal(comment)}>
+                    <EditRoundButton width="w-4" height="h-4" />
+                  </div>
+                  <DeleteRoundButton width="w-4" height="h-4" />
+                </div>
+              )}
+            </div>
+            <p className="py-0.5">{comment.comment}</p>
+          </li>
       ))}
+          <ModalWindow show={openModal} onClose={CloseEditCommentModal} >
+            <CommentForm diary={diary} comment={selectedComment} onClose={CloseEditCommentModal} isEdit={true}/>
+          </ModalWindow>  
     </ul>
     </>
   )

--- a/src/app/diaries/_components/CommentList.tsx
+++ b/src/app/diaries/_components/CommentList.tsx
@@ -15,7 +15,6 @@ interface CommentIndexProps extends CommentsProps {
 const CommentList: React.FC<CommentIndexProps> = ({ comments, currentUserId, diary, refreshComments }) => {
   const [openModal, setOpenModal] = useState<boolean>(false);
   const [selectedComment, setSelectedComment] = useState<CommentProps | null>(null);
-  const [refresh, setRefresh] = useState<boolean>(false);
 
   const openEditCommentModal = (comment: CommentProps) => {
     setSelectedComment(comment)
@@ -29,35 +28,33 @@ const CommentList: React.FC<CommentIndexProps> = ({ comments, currentUserId, dia
   }
 
   return(
-    <>
     <ul className="flex flex-col gap-2">
       {comments && comments.map((comment) => (
-          <li className="shadow-lg rounded-lg p-2" key={comment.id}>
-            <div className="flex justify-between items-center">
-              <div className="flex items-center gap-1">
-                <span className="rounded-full bg-primary text-white px-1">
-                  <span className="i-material-symbols-sound-detection-dog-barking-outline w-4 h-4"></span>
-                </span>
-                <span className="text-xs font-bold">{comment.owner.nickname}</span>
-              </div>
-
-              {comment.owner.id === currentUserId && (
-                <div className="flex gap-2">
-                  <div onClick={() => openEditCommentModal(comment)}>
-                    <EditRoundButton width="w-4" height="h-4" />
-                  </div>
-                  <DeleteRoundButton width="w-4" height="h-4" />
-                </div>
-              )}
+        <li className="shadow-lg rounded-lg p-2" key={comment.id}>
+          <div className="flex justify-between items-center">
+            <div className="flex items-center gap-1">
+              <span className="rounded-full bg-primary text-white px-1">
+                <span className="i-material-symbols-sound-detection-dog-barking-outline w-4 h-4"></span>
+              </span>
+              <span className="text-xs font-bold">{comment.owner.nickname}</span>
             </div>
-            <p className="py-0.5">{comment.comment}</p>
-          </li>
+
+            {comment.owner.id === currentUserId && (
+              <div className="flex gap-2">
+                <div onClick={() => openEditCommentModal(comment)}>
+                  <EditRoundButton width="w-4" height="h-4" />
+                </div>
+                <DeleteRoundButton width="w-4" height="h-4" />
+              </div>
+            )}
+          </div>
+          <p className="py-0.5">{comment.comment}</p>
+        </li>
       ))}
-          <ModalWindow show={openModal} onClose={CloseEditCommentModal} >
-            <CommentForm diary={diary} comment={selectedComment} onClose={CloseEditCommentModal} isEdit={true}/>
-          </ModalWindow>  
+        <ModalWindow show={openModal} onClose={CloseEditCommentModal} >
+          <CommentForm diary={diary} selectedComment={selectedComment} onClose={CloseEditCommentModal} isEdit={true}/>
+        </ModalWindow>  
     </ul>
-    </>
   )
 }
 export default CommentList;

--- a/src/app/diaries/_components/CommentList.tsx
+++ b/src/app/diaries/_components/CommentList.tsx
@@ -11,7 +11,7 @@ const CommentList: React.FC<CommentIndexProps> = ({ comments, currentUserId }) =
   return(
     <>
     <ul className="flex flex-col gap-2">
-      {comments.map((comment) => (
+      {comments && comments.map((comment) => (
         <li className="shadow-lg rounded-lg p-2" key={comment.id}>
           <div className="flex justify-between items-center">
             <div className="flex items-center gap-1">

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -102,7 +102,7 @@ const SummaryDetail: React.FC = () => {
           <div className="flex justify-end gap-3 my-2">
             {session?.user.id === summary.ownerId && (
               <>
-                <EditRoundButton EditClick={() => openEditModal()} width="w-8" height="h-8"/>
+                <EditRoundButton editClick={() => openEditModal()} width="w-8" height="h-8"/>
                 <DeleteRoundButton DeleteClick={() => openDeleteModal()} width="w-8" height="h-8"/>
               </>
               )}


### PR DESCRIPTION
# what
ユーザーが投稿済みのコメントを編集できるようにするため。

# why
以下の実装を行いました。

- 日記詳細ページで投稿済みのコメントに表示されている編集ボタンをクリックすると編集ページに遷移する。
- 編集ページでは既に投稿済みのコメントが表示される。
- 情報を編集し、「更新」ボタンをクリックすると、データベースに編集した内容が保存される。
- 更新が完了したら、詳細ページに遷移する。
- 編集ボタンはコメント投稿者のみ表示される。