### PR TITLE
コメント削除機能_フロント実装

### DIFF
--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -179,7 +179,13 @@ const DiaryDetail: React.FC = () => {
             
             {/* コメント一覧表示 */}
             <div>
-              <CommentList comments={diary.comments} diary={diary} currentUserId={currentUserId} refreshComments={refreshComments}/>
+              <CommentList 
+                comments={diary.comments} 
+                diary={diary} 
+                currentUserId={currentUserId}
+                refreshComments={refreshComments}
+                token={token}
+              />
             </div>
           </div>
           {/* モーダル表示エリア */}

--- a/src/app/diaries/_components/CommentList.tsx
+++ b/src/app/diaries/_components/CommentList.tsx
@@ -21,11 +21,12 @@ const CommentList: React.FC<CommentIndexProps> = ({ comments, currentUserId, dia
     setOpenModal(true);
   }
 
-  const CloseEditCommentModal = () => {
+  const closeEditCommentModal = () => {
     setOpenModal(false);
     setSelectedComment(null);
     refreshComments();
   }
+
 
   return(
     <ul className="flex flex-col gap-2">
@@ -44,15 +45,17 @@ const CommentList: React.FC<CommentIndexProps> = ({ comments, currentUserId, dia
                 <div onClick={() => openEditCommentModal(comment)}>
                   <EditRoundButton width="w-4" height="h-4" />
                 </div>
-                <DeleteRoundButton width="w-4" height="h-4" />
+                <div >
+                  <DeleteRoundButton width="w-4" height="h-4" />
+                </div>
               </div>
             )}
           </div>
           <p className="py-0.5">{comment.comment}</p>
         </li>
       ))}
-        <ModalWindow show={openModal} onClose={CloseEditCommentModal} >
-          <CommentForm diary={diary} selectedComment={selectedComment} onClose={CloseEditCommentModal} isEdit={true}/>
+        <ModalWindow show={openModal} onClose={closeEditCommentModal} >
+          <CommentForm diary={diary} selectedComment={selectedComment} onClose={closeEditCommentModal} isEdit={true}/>
         </ModalWindow>  
     </ul>
   )


### PR DESCRIPTION
# what
ユーザーが投稿済みのコメントを削除できるようにするため。

# why
以下の実装を行いました。

- 日記詳細ページで投稿済みのコメントに表示されている削除ボタンをクリックすると削除確認用モーダルが表示される。
- 削除確認モーダルで「キャンセル」ボタンをクリックすると、モーダルが閉じる。
- 削除確認モーダルで「削除」ボタンをクリックすると、データベースからコメントが削除される。
- 削除が完了したら、詳細ページに遷移する。
- 削除したコメントは詳細ページの一覧からも削除される。
- 削除ボタンはコメント投稿者のみ表示される。