### PR TITLE
MyPage機能_フロント実装

### DIFF
--- a/src/app/_components/Menu.tsx
+++ b/src/app/_components/Menu.tsx
@@ -9,7 +9,7 @@ const menuList = [
   { name: "記録", icon: "i-material-symbols-add-notes-outline", path: "/cares/new"},
   { name: "Calendar", icon: "i-material-symbols-calendar-month", path:"/cares" },
   { name: "日記", icon: "i-material-symbols-book-2-outline", path: "/diaries"},
-  { name: "Mypage", icon: "i-material-symbols-sound-detection-dog-barking-outline", path: "/mypages"},
+  { name: "Mypage", icon: "i-material-symbols-sound-detection-dog-barking-outline", path: "/mypage"},
 ]
 
 const excludedPaths = ["/", "/signup", "/signin", "/dogs/new", "/dogs/form"];

--- a/src/app/_components/PostUnit.tsx
+++ b/src/app/_components/PostUnit.tsx
@@ -6,10 +6,10 @@ import usePreviewImage from "@/_hooks/usePreviewImage";
 interface PostUnitUnitProps {
   id: string;
   title: string;
-  content: string;
+  content?: string;
   imageKey: string | null;
   defaultImage: StaticImageData;
-  tags: { id: string; name: string; }[] | null;
+  tags?: { id: string; name: string; }[] | null;
   linkPrefix: string;
 }
 

--- a/src/app/_components/PostUnit.tsx
+++ b/src/app/_components/PostUnit.tsx
@@ -26,12 +26,12 @@ const PostUnit: React.FC<PostUnitUnitProps> = ({
   const thumbnailImage = usePreviewImage(imageKey, "diary_img");
 
   return (
-    <div>
+    <div className="rounded-lg shadow">
       <Link href={`/${linkPrefix}/${id}`}>
         <div className="relative w-full h-auto">
           <div className="relative w-full h-0 pb-[100%]">
             <Image
-              className="rounded-lg shadow-xl drop-shadow-xl border-main bg-main"
+              className="rounded-t-lg shadow-md border-main bg-main"
               src={thumbnailImage ? thumbnailImage : defaultImage}
               alt={`${title} image`}
               fill
@@ -41,15 +41,15 @@ const PostUnit: React.FC<PostUnitUnitProps> = ({
             />
           </div>
         </div>
-        <div className="text-gray-800">
-          <p className="font-bold text-md">{title}</p>
+        <div className="text-gray-800 p-1">
+          <p className="font-bold text-sm">{title}</p>
           <p className="text-xs line-clamp-2">
             {content}
           </p>
         </div>
       </Link>
 
-      <div>
+      <div className="p-1">
         {tags && tags.length > 0 && (
           tags.map((tag) => (
             <span

--- a/src/app/api/mypages/route.ts
+++ b/src/app/api/mypages/route.ts
@@ -21,6 +21,7 @@ export const GET = async(request: NextRequest) => {
             name: true,
             sex: true,
             birthDate: true,
+            imageKey: true,
           },
         },
         diaries: {

--- a/src/app/api/mypages/route.ts
+++ b/src/app/api/mypages/route.ts
@@ -26,6 +26,7 @@ export const GET = async(request: NextRequest) => {
         },
         diaries: {
           select: {
+            id: true,
             title: true,
             imageKey: true,
             createdAt: true,
@@ -36,6 +37,7 @@ export const GET = async(request: NextRequest) => {
         },
         summaries: {
           select: {
+            id: true,
             title: true,
             createdAt: true,
           },
@@ -47,6 +49,7 @@ export const GET = async(request: NextRequest) => {
           select: {
             diary: {
               select: {
+                id: true,
                 title: true,
                 imageKey: true,
                 createdAt: true,

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -16,6 +16,7 @@ import { WeightInfo } from "@/_types/weight";
 import { TodayCareInfo } from "@/_types/care";
 import { DogProfile } from "@/_types/dog";
 import usePreviewImage from "@/_hooks/usePreviewImage";
+import { getAgeInMonths } from "../utils/getAgeInMonths";
 
 interface DogInfo {
   id: string;
@@ -69,15 +70,6 @@ const Home: React.FC = () => {
     }
     fetchDogInfo();
   }, [token, session]);
-
-  const getAgeInMonths = (birthday: string) => {
-    const today = new Date();
-    const birthDate = new Date(birthday);
-    const years = today.getFullYear() - birthDate.getFullYear();
-    const months = today.getMonth() - birthDate.getMonth();
-
-    return `${years}歳${months}ヶ月`
-  }
 
   return(
     <div className="flex justify-center text-gray-800">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import React, { useEffect, useState } from "react";
+import { useRouteGuard } from "@/_hooks/useRouteGuard";
+import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
+import { toast, Toaster } from "react-hot-toast"
+import Image from "next/image";
+import PageLoading from "../_components/PageLoading";
+
+interface MypageUser {
+  id: string;
+  nickname: string;
+  dog: { name: string, sex: string, birthDate: string };
+  diaries: { title: string, imageKey: string, createdAt: string }[];
+  summaries: { title: string, imageKey: string, createdAt: string }[];
+  bookmarks: { title: string, createdAt: string}[];
+}
+
+
+const MyPage: React.FC<MypageUser> = () => {
+  useRouteGuard();
+  const { token } = useSupabaseSession();
+  const [currentUser, setCurrentUser] = useState<MypageUser | null>(null);
+  console.log(currentUser)
+
+  useEffect(() => {
+    if(!token) return;
+    
+    const loggedInUser = async() => {
+      try {
+        const response = await fetch(`/api/mypages`, {
+          headers: {
+            "Content-Type" : "application/json",
+            Authorization: token,
+          },
+        });
+
+        if (response.status !== 200) {
+          toast.error("接続に失敗しました");
+          throw new Error("Network response was not OK");
+        }
+
+        const { userInfo } = await response.json();
+        setCurrentUser(userInfo);
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    loggedInUser();
+  }, [token]);
+
+  return(
+    <div className="flex justify-center text-gray-800">
+      <div className="w-64 my-20 pb-20 flex flex-col gap-10 overflow-y: auto">
+        {currentUser ? (
+          <>
+            <h2 className="text-2xl font-bold text-primary text-center">マイページ</h2>
+            
+            {/* user情報 */}
+            <div>
+              <div>
+                {/* <Image 
+                  className="w-28 h-28 rounded-full border border-primary ring-primary ring-offset-2 ring"
+                  src={dogImage} 
+                  alt="profile_image" 
+                  width={112} 
+                  height={112}
+                  style={{objectFit: "cover"}}
+                  priority={true}
+                /> */}
+              </div>
+
+              <div>
+                <p>{currentUser?.nickname}</p>
+                <ul>
+                  <li>投稿</li>
+                  <li>フォロー</li>
+                  <li>フォロワー</li>
+                </ul>
+                <div>プロフィール編集</div>
+              </div>
+            </div>
+          </>
+        ) : (
+          <PageLoading />
+        )}
+        <Toaster />
+      </div>
+    </div>
+  )
+}
+export default MyPage;

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -101,14 +101,14 @@ const MyPage: React.FC<MypageUser> = () => {
 
   return (
     <div className="flex justify-center text-gray-800">
-      <div className="my-20 pb-20 px-4 w-full max-w-screen-lg flex flex-col gap-10 overflow-y-auto">
+      <div className="my-20 pb-20 px-4 w-full max-w-screen-lg flex flex-col gap-12 overflow-y-auto">
         {currentUser ? (
           <>
             <h2 className="text-2xl font-bold text-primary text-center">マイページ</h2>
             {/* user情報 */}
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-4">
               <div className="flex flex-col items-center">
-                <span className="i-material-symbols-light-account-circle-outline w-14 h-14"></span>
+                <span className="i-material-symbols-light-account-circle-outline w-20 h-20"></span>
                 <p className="text-xl font-bold text-center">{currentUser?.nickname}</p>
               </div>
 
@@ -135,23 +135,21 @@ const MyPage: React.FC<MypageUser> = () => {
             {/* user情報 */}
 
             {/* ペット情報 */}
-            <div className="flex flex-col gap-3">
-              <h3 className="text-lg text-primary font-bold">マイペット</h3>
+            <div className="flex flex-col gap-3 border border-main shadow-xl p-4 rounded-lg">
+              <h3 className="text-lg text-primary font-bold text-center">マイペット</h3>
 
               <div className="flex justify-around">
-                <div>
-                  <Image 
-                    className="w-14 h-14 rounded-full border border-primary ring-primary ring-offset-1 ring"
-                    src={dogImg ? dogImg : no_registration} 
-                    alt="profile_image" 
-                    width={112} 
-                    height={112}
-                    style={{objectFit: "cover"}}
-                    priority={true}
-                  />
-                </div>
+                <Image 
+                  className="w-20 h-20 rounded-full border border-primary ring-primary ring-offset-1 ring"
+                  src={dogImg ? dogImg : no_registration} 
+                  alt="profile_image" 
+                  width={120} 
+                  height={120}
+                  style={{objectFit: "cover"}}
+                  priority={true}
+                />
 
-                <div>
+                <div className="flex flex-col justify-around">
                   <p className="text-xl font-bold text-center">{currentUser.dog.name}</p>
                   <div className="flex gap-2">
                     <p>{getAgeInMonths(currentUser.dog.birthDate)}</p>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -97,7 +97,7 @@ const MyPage: React.FC<MypageUser> = () => {
 
   return (
     <div className="flex justify-center text-gray-800">
-      <div className="w-64 my-20 pb-20 flex flex-col gap-10 overflow-y-auto">
+      <div className="my-20 pb-20 px-4 w-full max-w-screen-lg flex flex-col gap-10 overflow-y-auto">
         {currentUser ? (
           <>
             <h2 className="text-2xl font-bold text-primary text-center">マイページ</h2>
@@ -159,25 +159,25 @@ const MyPage: React.FC<MypageUser> = () => {
 
             <div>
               <ul className="flex text-sm font-medium text-center bg-secondary text-gray-500 rounded-lg dark:text-gray-400">
-                <li className="me-2 w-1/3">
+                <li className="w-1/3 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white rounded-lg">
                   <button
                     onClick={() => selectTab("日記")}
-                    className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
+                    className="inline-block text-gray-800 px-2 py-1.5" aria-current="page">
                       日記
                   </button>
                 </li>
 
-                <li className="me-2 w-1/3">
+                <li className="w-1/3 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white rounded-lg">
                   <button
                     onClick={() => selectTab("まとめ")}
-                    className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
+                    className="inline-block text-gray-800 px-2 py-1.5"  aria-current="page">
                       まとめ
                   </button>
                 </li>
-                <li className="me-2 w-1/3">
+                <li className="w-1/3 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white rounded-lg">
                   <button
                     onClick={() => selectTab("いいね")}
-                    className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
+                    className="inline-block text-gray-800 px-2 py-1.5" aria-current="page">
                       いいね
                   </button>
                 </li>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -38,6 +38,7 @@ const MyPage: React.FC<MypageUser> = () => {
   const dogImg = usePreviewImage(currentUser?.dog.imageKey ?? null, "profile_img");
   const [defaultImg, setDefaultImg] = useState<StaticImageData>(no_diary_img);
   const [selectedTab, setSelectedTab] = useState<string>("日記"); 
+  const [linkPrefix, setLinkPrefix] = useState<string>("");
   const [showLists, setShowLists] = useState<Lists[]>([]);
 
   useEffect(() => {
@@ -78,12 +79,15 @@ const MyPage: React.FC<MypageUser> = () => {
       if (selectedTab === "日記") {
         setShowLists(currentUser.diaries);
         setDefaultImg(no_diary_img);
+        setLinkPrefix("diaries")
       } else if (selectedTab === "まとめ") {
         setShowLists(currentUser.summaries);
         setDefaultImg(summaryThumbnail);
+        setLinkPrefix("summaries")
       } else if (selectedTab === "いいね") {
         setShowLists(currentUser.bookmarks);
         setDefaultImg(no_diary_img);
+        setLinkPrefix("favorites")
       }
     } catch (error) {
       console.log(error);
@@ -158,8 +162,8 @@ const MyPage: React.FC<MypageUser> = () => {
             </div>
 
             <div>
-              <ul className="flex text-sm font-medium text-center bg-secondary text-gray-500 rounded-lg dark:text-gray-400">
-                <li className="w-1/3 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white rounded-lg">
+              <ul className="flex text-sm font-medium text-center bg-secondary rounded-lg">
+                <li className="w-1/3 rounded-lg">
                   <button
                     onClick={() => selectTab("日記")}
                     className="inline-block text-gray-800 px-2 py-1.5" aria-current="page">
@@ -167,14 +171,14 @@ const MyPage: React.FC<MypageUser> = () => {
                   </button>
                 </li>
 
-                <li className="w-1/3 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white rounded-lg">
+                <li className="w-1/3 border-r border-l border-main">
                   <button
                     onClick={() => selectTab("まとめ")}
                     className="inline-block text-gray-800 px-2 py-1.5"  aria-current="page">
                       まとめ
                   </button>
                 </li>
-                <li className="w-1/3 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white rounded-lg">
+                <li className="w-1/3 rounded-lg">
                   <button
                     onClick={() => selectTab("いいね")}
                     className="inline-block text-gray-800 px-2 py-1.5" aria-current="page">
@@ -199,14 +203,14 @@ const MyPage: React.FC<MypageUser> = () => {
                       title={list.title} 
                       imageKey={list.imageKey} 
                       defaultImage={defaultImg} 
-                      linkPrefix="diaries" />
+                      linkPrefix={linkPrefix} />
                     )
                   })
                   }
                 </div>
               </InfiniteScroll>
             ) : (
-              <p className="text-center">投稿した{selectedTab}はありません</p>
+              <p className="text-center">登録した{selectedTab}はありません</p>
             )}
             </div>
           </>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -6,11 +6,13 @@ import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import { toast, Toaster } from "react-hot-toast"
 import Image from "next/image";
 import PageLoading from "../_components/PageLoading";
+import usePreviewImage from "@/_hooks/usePreviewImage";
+import no_registration from "@/public/dog_registration.png";
 
 interface MypageUser {
   id: string;
   nickname: string;
-  dog: { name: string, sex: string, birthDate: string };
+  dog: { name: string, sex: string, birthDate: string, imageKey: string };
   diaries: { title: string, imageKey: string, createdAt: string }[];
   summaries: { title: string, imageKey: string, createdAt: string }[];
   bookmarks: { title: string, createdAt: string}[];
@@ -22,6 +24,7 @@ const MyPage: React.FC<MypageUser> = () => {
   const { token } = useSupabaseSession();
   const [currentUser, setCurrentUser] = useState<MypageUser | null>(null);
   console.log(currentUser)
+  const dogImg = usePreviewImage(currentUser?.dog.imageKey ?? null, "profile_img");
 
   useEffect(() => {
     if(!token) return;
@@ -49,37 +52,81 @@ const MyPage: React.FC<MypageUser> = () => {
     loggedInUser();
   }, [token]);
 
+  const getAgeInMonths = (birthday: string) => {
+    const today = new Date();
+    const birthDate = new Date(birthday);
+    let years = today.getFullYear() - birthDate.getFullYear();
+    let months = today.getMonth() - birthDate.getMonth();
+    
+    if(months < 0) {
+      years--;
+      months +=12;
+    }
+    return `${years}歳${months}ヶ月`
+  }
+
   return(
     <div className="flex justify-center text-gray-800">
       <div className="w-64 my-20 pb-20 flex flex-col gap-10 overflow-y: auto">
         {currentUser ? (
           <>
             <h2 className="text-2xl font-bold text-primary text-center">マイページ</h2>
-            
             {/* user情報 */}
-            <div>
-              <div>
-                {/* <Image 
-                  className="w-28 h-28 rounded-full border border-primary ring-primary ring-offset-2 ring"
-                  src={dogImage} 
-                  alt="profile_image" 
-                  width={112} 
-                  height={112}
-                  style={{objectFit: "cover"}}
-                  priority={true}
-                /> */}
+            <div className="flex flex-col gap-2">
+              <div className="flex flex-col items-center">
+                <span className="i-material-symbols-light-account-circle-outline w-14 h-14"></span>
+                <p className="text-xl font-bold text-center">{currentUser?.nickname}</p>
               </div>
 
-              <div>
-                <p>{currentUser?.nickname}</p>
-                <ul>
-                  <li>投稿</li>
-                  <li>フォロー</li>
-                  <li>フォロワー</li>
-                </ul>
-                <div>プロフィール編集</div>
+              <ul className="flex">
+                <li className="text-center w-1/3">
+                  <p className="font-bold">{currentUser.diaries.length}</p>
+                  <p className="text-xs">投稿</p>
+                </li>
+                <li className="text-center w-1/3">
+                  <p className="font-bold">{currentUser.diaries.length}</p>
+                  <p className="text-xs">フォロー</p>
+                </li>
+                <li className="text-center w-1/3">
+                  <p className="font-bold">{currentUser.diaries.length}</p>
+                  <p className="text-xs">フォロワー</p>
+                </li>
+              </ul>
+
+              <div className="bg-primary rounded-lg text-white flex items-center justify-center py-1">
+                <span className="i-material-symbols-light-edit-square-outline w-5 h-5"></span>
+                <button>プロフィール編集</button>
               </div>
             </div>
+            {/* user情報 */}
+
+            {/* ペット情報 */}
+            <div className="flex flex-col gap-3">
+              <h3 className="text-lg text-primary font-bold">マイペット</h3>
+
+              <div className="flex justify-around">
+                <div>
+                  <Image 
+                    className="w-14 h-14 rounded-full border border-primary ring-primary ring-offset-1 ring"
+                    src={dogImg ? dogImg : no_registration} 
+                    alt="profile_image" 
+                    width={112} 
+                    height={112}
+                    style={{objectFit: "cover"}}
+                    priority={true}
+                  />
+                </div>
+
+                <div>
+                  <p className="text-xl font-bold text-center">{currentUser.dog.name}</p>
+                  <div className="flex gap-2">
+                    <p>{getAgeInMonths(currentUser.dog.birthDate)}</p>
+                    <p>{currentUser.dog.sex}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
           </>
         ) : (
           <PageLoading />

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -39,7 +39,7 @@ const MyPage: React.FC<MypageUser> = () => {
   const [defaultImg, setDefaultImg] = useState<StaticImageData>(no_diary_img);
   const [selectedTab, setSelectedTab] = useState<string>("diary"); 
   const [showLists, setShowLists] = useState<Lists[]>([]);
-  const [hasMore, setHasMore] = useState(true);
+  // const [hasMore, setHasMore] = useState(true);
 
   useEffect(() => {
     if(!token) return;
@@ -79,15 +79,12 @@ const MyPage: React.FC<MypageUser> = () => {
       if (selectedTab === "diary") {
         setShowLists(currentUser.diaries);
         setDefaultImg(no_diary_img);
-        setHasMore(false);
       } else if (selectedTab === "summary") {
         setShowLists(currentUser.summaries);
         setDefaultImg(summaryThumbnail);
-        setHasMore(false)
       } else if (selectedTab === "favorite") {
         setShowLists(currentUser.bookmarks);
         setDefaultImg(no_diary_img);
-        setHasMore(false);
       }
     } catch (error) {
       console.log(error);
@@ -164,25 +161,25 @@ const MyPage: React.FC<MypageUser> = () => {
             <div>
               <ul className="flex text-sm font-medium text-center bg-secondary text-gray-500 rounded-lg dark:text-gray-400">
                 <li className="me-2 w-1/3">
-                    <button
-                      onClick={() => selectTab("diary")}
-                      className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
-                        日記
-                    </button>
+                  <button
+                    onClick={() => selectTab("diary")}
+                    className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
+                      日記
+                  </button>
                 </li>
 
                 <li className="me-2 w-1/3">
                   <button
-                      onClick={() => selectTab("summary")}
-                      className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
-                        まとめ
-                    </button>
+                    onClick={() => selectTab("summary")}
+                    className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
+                      まとめ
+                  </button>
                 </li>
                 <li className="me-2 w-1/3">
                   <button
-                      onClick={() => selectTab("favorite")}
-                      className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
-                        いいね
+                    onClick={() => selectTab("favorite")}
+                    className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
+                      いいね
                   </button>
                 </li>
               </ul>
@@ -191,7 +188,6 @@ const MyPage: React.FC<MypageUser> = () => {
             <div>
             <InfiniteScroll 
               loadMore={SelectLists}
-              hasMore={hasMore}
               loader={<LoadingDiary key={0} />}
             >
               <div className="grid grid-cols-2 md:grid-cols-3 gap-4">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -8,6 +8,7 @@ import Image from "next/image";
 import PageLoading from "../_components/PageLoading";
 import usePreviewImage from "@/_hooks/usePreviewImage";
 import no_registration from "@/public/dog_registration.png";
+import { getAgeInMonths } from "../utils/getAgeInMonths";
 
 interface MypageUser {
   id: string;
@@ -51,19 +52,6 @@ const MyPage: React.FC<MypageUser> = () => {
     }
     loggedInUser();
   }, [token]);
-
-  const getAgeInMonths = (birthday: string) => {
-    const today = new Date();
-    const birthDate = new Date(birthday);
-    let years = today.getFullYear() - birthDate.getFullYear();
-    let months = today.getMonth() - birthDate.getMonth();
-    
-    if(months < 0) {
-      years--;
-      months +=12;
-    }
-    return `${years}歳${months}ヶ月`
-  }
 
   return(
     <div className="flex justify-center text-gray-800">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -37,9 +37,8 @@ const MyPage: React.FC<MypageUser> = () => {
   const [currentUser, setCurrentUser] = useState<MypageUser | null>(null);
   const dogImg = usePreviewImage(currentUser?.dog.imageKey ?? null, "profile_img");
   const [defaultImg, setDefaultImg] = useState<StaticImageData>(no_diary_img);
-  const [selectedTab, setSelectedTab] = useState<string>("diary"); 
+  const [selectedTab, setSelectedTab] = useState<string>("日記"); 
   const [showLists, setShowLists] = useState<Lists[]>([]);
-  // const [hasMore, setHasMore] = useState(true);
 
   useEffect(() => {
     if(!token) return;
@@ -76,13 +75,13 @@ const MyPage: React.FC<MypageUser> = () => {
     if (!currentUser) return;
 
     try {
-      if (selectedTab === "diary") {
+      if (selectedTab === "日記") {
         setShowLists(currentUser.diaries);
         setDefaultImg(no_diary_img);
-      } else if (selectedTab === "summary") {
+      } else if (selectedTab === "まとめ") {
         setShowLists(currentUser.summaries);
         setDefaultImg(summaryThumbnail);
-      } else if (selectedTab === "favorite") {
+      } else if (selectedTab === "いいね") {
         setShowLists(currentUser.bookmarks);
         setDefaultImg(no_diary_img);
       }
@@ -162,7 +161,7 @@ const MyPage: React.FC<MypageUser> = () => {
               <ul className="flex text-sm font-medium text-center bg-secondary text-gray-500 rounded-lg dark:text-gray-400">
                 <li className="me-2 w-1/3">
                   <button
-                    onClick={() => selectTab("diary")}
+                    onClick={() => selectTab("日記")}
                     className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
                       日記
                   </button>
@@ -170,14 +169,14 @@ const MyPage: React.FC<MypageUser> = () => {
 
                 <li className="me-2 w-1/3">
                   <button
-                    onClick={() => selectTab("summary")}
+                    onClick={() => selectTab("まとめ")}
                     className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
                       まとめ
                   </button>
                 </li>
                 <li className="me-2 w-1/3">
                   <button
-                    onClick={() => selectTab("favorite")}
+                    onClick={() => selectTab("いいね")}
                     className="inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white" aria-current="page">
                       いいね
                   </button>
@@ -186,25 +185,29 @@ const MyPage: React.FC<MypageUser> = () => {
             </div>
 
             <div>
-            <InfiniteScroll 
-              loadMore={SelectLists}
-              loader={<LoadingDiary key={0} />}
-            >
-              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                {showLists.map((list) => {
-                  return(
-                  <PostUnit 
-                    id={list.id} 
-                    key={list.id}
-                    title={list.title} 
-                    imageKey={list.imageKey} 
-                    defaultImage={defaultImg} 
-                    linkPrefix="diaries" />
-                  )
-                })
-                }
-              </div>
-            </InfiniteScroll>
+            {(showLists && showLists.length > 0) ? (
+              <InfiniteScroll 
+                loadMore={SelectLists}
+                loader={<LoadingDiary key={0} />}
+              >
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                  {showLists.map((list) => {
+                    return(
+                    <PostUnit 
+                      id={list.id} 
+                      key={list.id}
+                      title={list.title} 
+                      imageKey={list.imageKey} 
+                      defaultImage={defaultImg} 
+                      linkPrefix="diaries" />
+                    )
+                  })
+                  }
+                </div>
+              </InfiniteScroll>
+            ) : (
+              <p className="text-center">投稿した{selectedTab}はありません</p>
+            )}
             </div>
           </>
           ) : (

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -31,7 +31,7 @@ interface Lists {
   createdAt: string;
 }
 
-const MyPage: React.FC<MypageUser> = () => {
+const MyPage: React.FC = () => {
   useRouteGuard();
   const { token } = useSupabaseSession();
   const [currentUser, setCurrentUser] = useState<MypageUser | null>(null);

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -19,19 +19,12 @@ interface MypageUser {
   id: string;
   nickname: string;
   dog: { name: string, sex: string, birthDate: string, imageKey: string };
-  diaries: { id: string, title: string, imageKey: string, createdAt: string }[];
-  summaries: { id: string, title: string, imageKey: string, createdAt: string }[];
-  bookmarks: { id: string, title: string, imageKey: string, createdAt: string }[];
+  diaries: Lists[];
+  summaries: Lists[];
+  bookmarks: Lists[];
 }
 
 interface Lists {
-  id: string;
-  title: string;
-  imageKey: string;
-  createdAt: string;
-}
-
-interface bookmark {
   id: string;
   title: string;
   imageKey: string;
@@ -45,7 +38,7 @@ const MyPage: React.FC<MypageUser> = () => {
   const dogImg = usePreviewImage(currentUser?.dog.imageKey ?? null, "profile_img");
   const [defaultImg, setDefaultImg] = useState<StaticImageData>(no_diary_img);
   const [selectedTab, setSelectedTab] = useState<string>("diary"); 
-  const [showLists, setShowLists] = useState<Lists[] | bookmark[]>([]);
+  const [showLists, setShowLists] = useState<Lists[]>([]);
   const [hasMore, setHasMore] = useState(true);
 
   useEffect(() => {

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -10,6 +10,10 @@ import usePreviewImage from "@/_hooks/usePreviewImage";
 import no_registration from "@/public/dog_registration.png";
 import { getAgeInMonths } from "../utils/getAgeInMonths";
 
+import { Tabs } from "flowbite-react";
+import { HiAdjustments, HiClipboardList, HiUserCircle } from "react-icons/hi";
+import { MdDashboard } from "react-icons/md";
+
 interface MypageUser {
   id: string;
   nickname: string;
@@ -115,6 +119,24 @@ const MyPage: React.FC<MypageUser> = () => {
               </div>
             </div>
 
+            {/* リスト一覧 */}
+            <div>
+              <ul className="flex text-sm font-medium text-center bg-secondary text-gray-500 rounded-lg dark:text-gray-400">
+                <li className="me-2 w-1/3">
+                    <button className={`inline-block text-gray-800 px-2 py-1.5 rounded-lg active hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white`} aria-current="page">
+                        日記
+                    </button>
+                </li>
+
+                <li className="me-2 w-1/3">
+                    <a href="#"  className="inline-block px-2 py-1.5 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">まとめ</a>
+                </li>
+                <li className="me-2 w-1/3">
+                    <a href="#" className="inline-block px-2 py-1.5 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">いいね</a>
+                </li>
+              </ul>
+              
+            </div>
           </>
         ) : (
           <PageLoading />

--- a/src/app/utils/getAgeInMonths.ts
+++ b/src/app/utils/getAgeInMonths.ts
@@ -1,0 +1,12 @@
+export const getAgeInMonths = (birthday: string) => {
+  const today = new Date();
+  const birthDate = new Date(birthday);
+  let years = today.getFullYear() - birthDate.getFullYear();
+  let months = today.getMonth() - birthDate.getMonth();
+  
+  if(months < 0) {
+    years--;
+    months +=12;
+  }
+  return `${years}歳${months}ヶ月`
+}


### PR DESCRIPTION
# Why
- ユーザーが自身の記事・まとめの投稿内容や、いいねをした記事一覧を一元管理できるようにするため。

# What
以下の実装を行いました。

- Menuバーから「Mypage」のアイコンをクリックすると、自身のマイページに遷移できる。
- マイページ一覧では自身のプロフィール情報、ペットの情報、投稿した記事/まとめ、いいねした記事の履歴が確認できる。
- 日記/まとめ/いいねのタブをクリックすると、自身の投稿/記録に紐づいたデータが表示される。
