### PR TITLE
リファクタリング/ユーザーページのコンポーネント化

### DIFF
--- a/src/_types/bookmark.ts
+++ b/src/_types/bookmark.ts
@@ -1,0 +1,6 @@
+export interface MypageBookmarkLists {
+  id: string;
+  title: string;
+  imageKey: string;
+  createdAt: string;
+}

--- a/src/_types/diary.ts
+++ b/src/_types/diary.ts
@@ -24,3 +24,10 @@ export interface DiaryDetails extends BaseDiary {
   owner: { id: string, nickname: string }
   comments: CommentProps[];
 }
+
+export interface MypageDiaryLists {
+  id: string;
+  title: string;
+  imageKey: string;
+  createdAt: string;
+}

--- a/src/_types/summary.ts
+++ b/src/_types/summary.ts
@@ -37,3 +37,10 @@ export interface SummaryDetails {
   createdAt: string
   updatedAt: string
 }
+
+export interface MypageSummaryLists {
+  id: string;
+  title: string;
+  imageKey: string;
+  createdAt: string;
+}

--- a/src/_types/user.ts
+++ b/src/_types/user.ts
@@ -1,0 +1,12 @@
+import { MypageDiaryLists } from "./diary";
+import { MypageSummaryLists } from "./summary";
+import { MypageBookmarkLists } from "./bookmark";
+
+export interface UserMyPage {
+  id: string;
+  nickname: string;
+  dog: { name: string, sex: string, birthDate: string, imageKey: string };
+  diaries: MypageDiaryLists[];
+  summaries: MypageSummaryLists[];
+  bookmarks: MypageBookmarkLists[];
+}

--- a/src/app/_components/UserForm.tsx
+++ b/src/app/_components/UserForm.tsx
@@ -114,7 +114,7 @@ const UserForm: React.FC<UserInfo> = ({ userNickname, userEmail, isEdit }) => {
         />
         
         {isEdit ? (
-          <p className="text-sm text-center">
+          <p className="text-sm text-center text-gray-800">
             パスワードの変更は
               <Link href={`/users/772cd76c-fe3a-4016-8c25-e5f53151e973/password-change`} className="text-primary font-bold">
                 こちら

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -70,7 +70,7 @@ const MyPage: React.FC = () => {
         setShowLists(currentUser.summaries);
         setDefaultImg(summaryThumbnail);
         setLinkPrefix("summaries")
-      } else if (selectedTab === "いいね") {
+      } else if (selectedTab === "お気に入り") {
         setShowLists(currentUser.bookmarks);
         setDefaultImg(no_diary_img);
         setLinkPrefix("favorites")

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -4,11 +4,9 @@ import React, { useEffect, useState } from "react";
 import { useRouteGuard } from "@/_hooks/useRouteGuard";
 import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import { toast, Toaster } from "react-hot-toast";
-import Image, { StaticImageData } from "next/image";
+import { StaticImageData } from "next/image";
 import PageLoading from "../_components/PageLoading";
 import usePreviewImage from "@/_hooks/usePreviewImage";
-import no_registration from "@/public/dog_registration.png";
-import { getAgeInMonths } from "../utils/getAgeInMonths";
 import InfiniteScroll from 'react-infinite-scroller';
 import LoadingDiary from "../diaries/_components/LoadingDiary";
 import PostUnit from "../_components/PostUnit";
@@ -19,6 +17,7 @@ import { MypageDiaryLists } from "@/_types/diary";
 import { MypageSummaryLists } from "@/_types/summary";
 import { MypageBookmarkLists } from "@/_types/bookmark";
 import UserInfo from "../users/[id]/_components/UserInfo";
+import UserDogInfo from "../users/[id]/_components/UserDogInfo";
 
 
 const MyPage: React.FC = () => {
@@ -95,32 +94,7 @@ const MyPage: React.FC = () => {
         {currentUser ? (
           <>
           <UserInfo user={currentUser} isMypage={true}/>
-
-
-            {/* ペット情報 */}
-            <div className="flex flex-col gap-3 border border-main shadow-xl p-4 rounded-lg">
-              <h3 className="text-lg text-primary font-bold text-center">マイペット</h3>
-
-              <div className="flex justify-around">
-                <Image 
-                  className="w-20 h-20 rounded-full border border-primary ring-primary ring-offset-1 ring"
-                  src={dogImg ? dogImg : no_registration} 
-                  alt="profile_image" 
-                  width={120} 
-                  height={120}
-                  style={{objectFit: "cover"}}
-                  priority={true}
-                />
-
-                <div className="flex flex-col justify-around">
-                  <p className="text-xl font-bold text-center">{currentUser.dog.name}</p>
-                  <div className="flex gap-2">
-                    <p>{getAgeInMonths(currentUser.dog.birthDate)}</p>
-                    <p>{currentUser.dog.sex}</p>
-                  </div>
-                </div>
-              </div>
-            </div>
+          <UserDogInfo user={currentUser} dogImg={dogImg}/>
 
             <div>
               <ul className="flex text-sm font-medium text-center bg-secondary rounded-lg">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -14,33 +14,22 @@ import LoadingDiary from "../diaries/_components/LoadingDiary";
 import PostUnit from "../_components/PostUnit";
 import no_diary_img from "@/public/no_diary_img.png";
 import summaryThumbnail from "@/public/summaryThumbnail.png";
-import Link from "next/link";
+import { UserMyPage } from "@/_types/user";
+import { MypageDiaryLists } from "@/_types/diary";
+import { MypageSummaryLists } from "@/_types/summary";
+import { MypageBookmarkLists } from "@/_types/bookmark";
+import UserInfo from "../users/[id]/_components/UserInfo";
 
-interface MypageUser {
-  id: string;
-  nickname: string;
-  dog: { name: string, sex: string, birthDate: string, imageKey: string };
-  diaries: Lists[];
-  summaries: Lists[];
-  bookmarks: Lists[];
-}
-
-interface Lists {
-  id: string;
-  title: string;
-  imageKey: string;
-  createdAt: string;
-}
 
 const MyPage: React.FC = () => {
   useRouteGuard();
   const { token } = useSupabaseSession();
-  const [currentUser, setCurrentUser] = useState<MypageUser | null>(null);
+  const [currentUser, setCurrentUser] = useState<UserMyPage | null>(null);
   const dogImg = usePreviewImage(currentUser?.dog.imageKey ?? null, "profile_img");
   const [defaultImg, setDefaultImg] = useState<StaticImageData>(no_diary_img);
   const [selectedTab, setSelectedTab] = useState<string>("日記"); 
   const [linkPrefix, setLinkPrefix] = useState<string>("");
-  const [showLists, setShowLists] = useState<Lists[]>([]);
+  const [showLists, setShowLists] = useState<MypageDiaryLists[] | MypageSummaryLists[] | MypageBookmarkLists[]>([]);
 
   useEffect(() => {
     if(!token) return;
@@ -105,39 +94,8 @@ const MyPage: React.FC = () => {
       <div className="my-20 pb-20 px-4 w-full max-w-screen-lg flex flex-col gap-12 overflow-y-auto">
         {currentUser ? (
           <>
-            <h2 className="text-2xl font-bold text-primary text-center">マイページ</h2>
-            {/* user情報 */}
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-col items-center">
-                <span className="i-material-symbols-light-account-circle-outline w-20 h-20"></span>
-                <p className="text-xl font-bold text-center">{currentUser?.nickname}</p>
-              </div>
+          <UserInfo user={currentUser} isMypage={true}/>
 
-              <ul className="flex">
-                <li className="text-center w-1/3">
-                  <p className="font-bold">{currentUser.diaries.length}</p>
-                  <p className="text-xs">投稿</p>
-                </li>
-                <li className="text-center w-1/3">
-                  <p className="font-bold">{currentUser.diaries.length}</p>
-                  <p className="text-xs">フォロー</p>
-                </li>
-                <li className="text-center w-1/3">
-                  <p className="font-bold">{currentUser.diaries.length}</p>
-                  <p className="text-xs">フォロワー</p>
-                </li>
-              </ul>
-
-              <div className="bg-primary rounded-lg text-white flex items-center justify-center py-1">
-                <span className="i-material-symbols-light-edit-square-outline w-5 h-5"></span>
-                <button>
-                  <Link href={`/users/${currentUser.id}/edit`}>
-                    プロフィール編集
-                  </Link>
-                </button>
-              </div>
-            </div>
-            {/* user情報 */}
 
             {/* ペット情報 */}
             <div className="flex flex-col gap-3 border border-main shadow-xl p-4 rounded-lg">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -7,9 +7,6 @@ import { toast, Toaster } from "react-hot-toast";
 import { StaticImageData } from "next/image";
 import PageLoading from "../_components/PageLoading";
 import usePreviewImage from "@/_hooks/usePreviewImage";
-import InfiniteScroll from 'react-infinite-scroller';
-import LoadingDiary from "../diaries/_components/LoadingDiary";
-import PostUnit from "../_components/PostUnit";
 import no_diary_img from "@/public/no_diary_img.png";
 import summaryThumbnail from "@/public/summaryThumbnail.png";
 import { UserMyPage } from "@/_types/user";
@@ -18,7 +15,7 @@ import { MypageSummaryLists } from "@/_types/summary";
 import { MypageBookmarkLists } from "@/_types/bookmark";
 import UserInfo from "../users/[id]/_components/UserInfo";
 import UserDogInfo from "../users/[id]/_components/UserDogInfo";
-
+import TabNavigation from "../users/[id]/_components/TabNavigation";
 
 const MyPage: React.FC = () => {
   useRouteGuard();
@@ -95,59 +92,15 @@ const MyPage: React.FC = () => {
           <>
           <UserInfo user={currentUser} isMypage={true}/>
           <UserDogInfo user={currentUser} dogImg={dogImg}/>
-
-            <div>
-              <ul className="flex text-sm font-medium text-center bg-secondary rounded-lg">
-                <li className="w-1/3 rounded-lg">
-                  <button
-                    onClick={() => selectTab("日記")}
-                    className="inline-block text-gray-800 px-2 py-1.5" aria-current="page">
-                      日記
-                  </button>
-                </li>
-
-                <li className="w-1/3 border-r border-l border-main">
-                  <button
-                    onClick={() => selectTab("まとめ")}
-                    className="inline-block text-gray-800 px-2 py-1.5"  aria-current="page">
-                      まとめ
-                  </button>
-                </li>
-                <li className="w-1/3 rounded-lg">
-                  <button
-                    onClick={() => selectTab("いいね")}
-                    className="inline-block text-gray-800 px-2 py-1.5" aria-current="page">
-                      いいね
-                  </button>
-                </li>
-              </ul>
-            </div>
-
-            <div>
-            {(showLists && showLists.length > 0) ? (
-              <InfiniteScroll 
-                loadMore={SelectLists}
-                loader={<LoadingDiary key={0} />}
-              >
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                  {showLists.map((list) => {
-                    return(
-                    <PostUnit 
-                      id={list.id} 
-                      key={list.id}
-                      title={list.title} 
-                      imageKey={list.imageKey} 
-                      defaultImage={defaultImg} 
-                      linkPrefix={linkPrefix} />
-                    )
-                  })
-                  }
-                </div>
-              </InfiniteScroll>
-            ) : (
-              <p className="text-center">登録した{selectedTab}はありません</p>
-            )}
-            </div>
+          <TabNavigation 
+            user={currentUser}
+            showLists={showLists}
+            defaultImg={defaultImg}
+            selectTab={selectTab}
+            SelectLists={SelectLists}
+            linkPrefix={linkPrefix}
+            selectedTab={selectedTab}
+          />
           </>
           ) : (
           <PageLoading />

--- a/src/app/users/[id]/_components/TabNavigation.tsx
+++ b/src/app/users/[id]/_components/TabNavigation.tsx
@@ -24,7 +24,7 @@ const TabNavigation: React.FC<showListsProps> = ({ user, showLists, defaultImg, 
   return(
     <>
       <div>
-        <p className="text-lg font-bold text-primary">{user.nickname}さんの投稿</p>
+        <p className="text-lg font-bold text-primary">{user.nickname}さんの投稿/お気に入り</p>
         <ul className="flex text-sm font-medium text-center bg-secondary rounded-lg">
           <li className="w-1/3 rounded-lg">
             <button
@@ -44,9 +44,9 @@ const TabNavigation: React.FC<showListsProps> = ({ user, showLists, defaultImg, 
           
           <li className="w-1/3 rounded-lg">
             <button
-              onClick={() => selectTab("いいね")}
+              onClick={() => selectTab("お気に入り")}
               className="inline-block text-gray-800 px-2 py-1.5" aria-current="page">
-                いいね
+                お気に入り
             </button>
           </li>
         </ul>

--- a/src/app/users/[id]/_components/TabNavigation.tsx
+++ b/src/app/users/[id]/_components/TabNavigation.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { UserMyPage } from "@/_types/user";
+import React from "react";
+import InfiniteScroll from 'react-infinite-scroller';
+import { MypageDiaryLists } from "@/_types/diary";
+import { MypageSummaryLists } from "@/_types/summary";
+import { MypageBookmarkLists } from "@/_types/bookmark";
+import LoadingDiary from "@/app/diaries/_components/LoadingDiary";
+import PostUnit from "@/app/_components/PostUnit";
+import { StaticImageData } from "next/image";
+
+interface showListsProps {
+  user: UserMyPage;
+  showLists: MypageDiaryLists[] | MypageSummaryLists[] | MypageBookmarkLists[] | [];
+  defaultImg: StaticImageData
+  selectTab: (tabName: string) => void;
+  SelectLists: () => void;
+  linkPrefix: string;
+  selectedTab: string;
+}
+
+const TabNavigation: React.FC<showListsProps> = ({ user, showLists, defaultImg, selectTab, SelectLists, linkPrefix, selectedTab }) => {
+  return(
+    <>
+      <div>
+        <p className="text-lg font-bold text-primary">{user.nickname}さんの投稿</p>
+        <ul className="flex text-sm font-medium text-center bg-secondary rounded-lg">
+          <li className="w-1/3 rounded-lg">
+            <button
+              onClick={() => selectTab("日記")}
+              className="inline-block text-gray-800 px-2 py-1.5" aria-current="page">
+                日記
+            </button>
+          </li>
+
+          <li className="w-1/3 border-r border-l border-main">
+            <button
+              onClick={() => selectTab("まとめ")}
+              className="inline-block text-gray-800 px-2 py-1.5"  aria-current="page">
+                まとめ
+            </button>
+          </li>
+          
+          <li className="w-1/3 rounded-lg">
+            <button
+              onClick={() => selectTab("いいね")}
+              className="inline-block text-gray-800 px-2 py-1.5" aria-current="page">
+                いいね
+            </button>
+          </li>
+        </ul>
+      </div>
+
+      <div>
+      {(showLists && showLists.length > 0) ? (
+        <InfiniteScroll 
+          loadMore={SelectLists}
+          loader={<LoadingDiary key={0} />}
+        >
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            {showLists.map((list) => {
+              return(
+              <PostUnit 
+                id={list.id} 
+                key={list.id}
+                title={list.title} 
+                imageKey={list.imageKey} 
+                defaultImage={defaultImg} 
+                linkPrefix={linkPrefix} />
+              )
+            })
+            }
+          </div>
+        </InfiniteScroll>
+      ) : (
+        <p className="text-center">登録した{selectedTab}はありません</p>
+      )}
+      </div>
+    </>
+
+  )
+}
+export default TabNavigation;

--- a/src/app/users/[id]/_components/UserDogInfo.tsx
+++ b/src/app/users/[id]/_components/UserDogInfo.tsx
@@ -13,7 +13,7 @@ interface DogInfoProps {
 const UserDogInfo: React.FC<DogInfoProps> = ({ user, dogImg }) => {
   return(
     <div className="flex flex-col gap-3 border border-main shadow-xl p-4 rounded-lg">
-      <h3 className="text-lg text-primary font-bold text-center">マイペット</h3>
+      <h3 className="text-lg text-primary font-bold text-center">わんちゃん情報</h3>
 
       <div className="flex justify-around">
         <Image 

--- a/src/app/users/[id]/_components/UserDogInfo.tsx
+++ b/src/app/users/[id]/_components/UserDogInfo.tsx
@@ -12,7 +12,7 @@ interface DogInfoProps {
 
 const UserDogInfo: React.FC<DogInfoProps> = ({ user, dogImg }) => {
   return(
-    <div className="flex flex-col gap-3 border border-main shadow-xl p-4 rounded-lg">
+    <div className="flex flex-col gap-3 border border-main shadow-[0_2px_5px_rgb(0,0,0,0.2)] pt-4 pb-6 px-4 rounded-lg">
       <h3 className="text-lg text-primary font-bold text-center">わんちゃん情報</h3>
 
       <div className="flex justify-around">

--- a/src/app/users/[id]/_components/UserDogInfo.tsx
+++ b/src/app/users/[id]/_components/UserDogInfo.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import React from "react";
+import Image from "next/image";
+import { UserMyPage } from "@/_types/user";
+import { getAgeInMonths } from "@/app/utils/getAgeInMonths";
+import no_registration from "@/public/dog_registration.png";
+interface DogInfoProps {
+  user: UserMyPage;
+  dogImg: string | null;
+}
+
+const UserDogInfo: React.FC<DogInfoProps> = ({ user, dogImg }) => {
+  return(
+    <div className="flex flex-col gap-3 border border-main shadow-xl p-4 rounded-lg">
+      <h3 className="text-lg text-primary font-bold text-center">マイペット</h3>
+
+      <div className="flex justify-around">
+        <Image 
+          className="w-20 h-20 rounded-full border border-primary ring-primary ring-offset-1 ring"
+          src={dogImg ? dogImg : no_registration} 
+          alt="profile_image" 
+          width={120} 
+          height={120}
+          style={{objectFit: "cover"}}
+          priority={true}
+        />
+
+        <div className="flex flex-col justify-around">
+          <p className="text-xl font-bold text-center">{user.dog.name}</p>
+          <div className="flex gap-2">
+            <p>{getAgeInMonths(user.dog.birthDate)}</p>
+            <p>{user.dog.sex}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+export default UserDogInfo;

--- a/src/app/users/[id]/_components/UserInfo.tsx
+++ b/src/app/users/[id]/_components/UserInfo.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import React from "react";
+
+const UserInfo: React.FC = () => {
+  return(
+    <>
+    </>
+  )
+}
+export default UserInfo;

--- a/src/app/users/[id]/_components/UserInfo.tsx
+++ b/src/app/users/[id]/_components/UserInfo.tsx
@@ -1,11 +1,53 @@
 "use client"
 
 import React from "react";
+import { UserMyPage } from "@/_types/user";
+import Link from "next/link";
 
-const UserInfo: React.FC = () => {
+interface UserInfoProps {
+  user: UserMyPage;
+  isMypage: boolean;
+}
+
+const UserInfo: React.FC<UserInfoProps> = ({ user, isMypage }) => {
   return(
     <>
-    </>
+      <h2 className="text-2xl font-bold text-primary text-center">{isMypage ? "マイページ" : `${user?.nickname}さんのページ`}</h2>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col items-center">
+          <span className="i-material-symbols-light-account-circle-outline w-20 h-20"></span>
+          <p className="text-xl font-bold text-center">{user?.nickname}</p>
+        </div>
+
+        <ul className="flex">
+          <li className="text-center w-1/3">
+            <p className="font-bold">{user.diaries.length}</p>
+            <p className="text-xs">投稿</p>
+          </li>
+          <li className="text-center w-1/3">
+            <p className="font-bold">{user.diaries.length}</p>
+            <p className="text-xs">フォロー</p>
+          </li>
+          <li className="text-center w-1/3">
+            <p className="font-bold">{user.diaries.length}</p>
+            <p className="text-xs">フォロワー</p>
+          </li>
+        </ul>
+
+        <div className="bg-primary rounded-lg text-white flex items-center justify-center py-1">
+          <span className="i-ri-user-follow-line w-5 h-5"></span>
+          {isMypage ? (
+            <button>
+              <Link href={`/users/${user.id}/edit`}>
+                プロフィール編集
+              </Link>
+              </button>
+          ) : (
+            <button>フォローする</button>
+          )}
+        </div>
+      </div>
+  </>
   )
 }
 export default UserInfo;

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -10,9 +10,6 @@ import usePreviewImage from "@/_hooks/usePreviewImage";
 import no_diary_img from "@/public/no_diary_img.png";
 import summaryThumbnail from "@/public/summaryThumbnail.png";
 import PageLoading from "@/app/_components/PageLoading";
-import InfiniteScroll from 'react-infinite-scroller';
-import LoadingDiary from "@/app/diaries/_components/LoadingDiary";
-import PostUnit from "@/app/_components/PostUnit";
 import { useRouter } from "next/navigation";
 import UserInfo from "./_components/UserInfo";
 import { UserMyPage } from "@/_types/user";
@@ -20,6 +17,7 @@ import { MypageDiaryLists } from "@/_types/diary";
 import { MypageSummaryLists } from "@/_types/summary";
 import { MypageBookmarkLists } from "@/_types/bookmark";
 import UserDogInfo from "./_components/UserDogInfo";
+import TabNavigation from "./_components/TabNavigation";
 
 const UserPage: React.FC = () => {
   useRouteGuard();
@@ -103,63 +101,16 @@ const UserPage: React.FC = () => {
           <>
           <UserInfo user={otherUser} isMypage={false}/>
           <UserDogInfo user={otherUser} dogImg={dogImg} />
-
-            {/* タブの実装 */}
-            <div>
-              <p className="text-lg font-bold text-primary">{otherUser.nickname}さんの投稿</p>
-              <ul className="flex text-sm font-medium text-center bg-secondary rounded-lg">
-                <li className="w-1/3 rounded-lg">
-                  <button
-                    onClick={() => selectTab("日記")}
-                    className="inline-block text-gray-800 px-2 py-1.5" aria-current="page">
-                      日記
-                  </button>
-                </li>
-
-                <li className="w-1/3 border-r border-l border-main">
-                  <button
-                    onClick={() => selectTab("まとめ")}
-                    className="inline-block text-gray-800 px-2 py-1.5"  aria-current="page">
-                      まとめ
-                  </button>
-                </li>
-                <li className="w-1/3 rounded-lg">
-                  <button
-                    onClick={() => selectTab("いいね")}
-                    className="inline-block text-gray-800 px-2 py-1.5" aria-current="page">
-                      いいね
-                  </button>
-                </li>
-              </ul>
-            </div>
-
-            <div>
-            {(showLists && showLists.length > 0) ? (
-              <InfiniteScroll 
-                loadMore={SelectLists}
-                loader={<LoadingDiary key={0} />}
-              >
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                  {showLists.map((list) => {
-                    return(
-                    <PostUnit 
-                      id={list.id} 
-                      key={list.id}
-                      title={list.title} 
-                      imageKey={list.imageKey} 
-                      defaultImage={defaultImg} 
-                      linkPrefix={linkPrefix} />
-                    )
-                  })
-                  }
-                </div>
-              </InfiniteScroll>
-            ) : (
-              <p className="text-center">登録した{selectedTab}はありません</p>
-            )}
-            </div>
+          <TabNavigation 
+            user={otherUser}
+            showLists={showLists}
+            defaultImg={defaultImg}
+            selectTab={selectTab}
+            SelectLists={SelectLists}
+            linkPrefix={linkPrefix}
+            selectedTab={selectedTab}
+          />            
           </>
-
         ) : (
           <PageLoading />
         )}

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -16,22 +16,11 @@ import InfiniteScroll from 'react-infinite-scroller';
 import LoadingDiary from "@/app/diaries/_components/LoadingDiary";
 import PostUnit from "@/app/_components/PostUnit";
 import { useRouter } from "next/navigation";
-
-interface OtherUser {
-  id: string;
-  nickname: string;
-  dog: { name: string, sex: string, birthDate: string, imageKey: string };
-  diaries: Lists[];
-  summaries: Lists[];
-  bookmarks: Lists[];
-}
-
-interface Lists {
-  id: string;
-  title: string;
-  imageKey: string;
-  createdAt: string;
-}
+import UserInfo from "./_components/UserInfo";
+import { UserMyPage } from "@/_types/user";
+import { MypageDiaryLists } from "@/_types/diary";
+import { MypageSummaryLists } from "@/_types/summary";
+import { MypageBookmarkLists } from "@/_types/bookmark";
 
 const UserPage: React.FC = () => {
   useRouteGuard();
@@ -40,9 +29,9 @@ const UserPage: React.FC = () => {
   const { id } = params;
   const { token, session } = useSupabaseSession();
   const currentUserId = session?.user.id;
-  const [otherUser, setOtherUser] = useState<OtherUser | null>(null);
+  const [otherUser, setOtherUser] = useState<UserMyPage | null>(null);
   const dogImg = usePreviewImage(otherUser?.dog.imageKey ?? null, "profile_img");
-  const [showLists, setShowLists] = useState<Lists[]>([]);
+  const [showLists, setShowLists] = useState<MypageDiaryLists[] | MypageSummaryLists[] | MypageBookmarkLists[]>([]);
   const [selectedTab, setSelectedTab] = useState<string>("日記"); 
   const [linkPrefix, setLinkPrefix] = useState<string>("");
   const [defaultImg, setDefaultImg] = useState<StaticImageData>(no_diary_img);
@@ -113,33 +102,7 @@ const UserPage: React.FC = () => {
       <div className="my-20 pb-20 px-4 w-full max-w-screen-lg flex flex-col gap-12 overflow-y-auto">
         {otherUser ? (
           <>
-            <h2 className="text-2xl font-bold text-primary text-center">{otherUser?.nickname}さんのページ</h2>
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-col items-center">
-                <span className="i-material-symbols-light-account-circle-outline w-20 h-20"></span>
-                <p className="text-xl font-bold text-center">{otherUser?.nickname}</p>
-              </div>
-
-              <ul className="flex">
-                <li className="text-center w-1/3">
-                  <p className="font-bold">{otherUser.diaries.length}</p>
-                  <p className="text-xs">投稿</p>
-                </li>
-                <li className="text-center w-1/3">
-                  <p className="font-bold">{otherUser.diaries.length}</p>
-                  <p className="text-xs">フォロー</p>
-                </li>
-                <li className="text-center w-1/3">
-                  <p className="font-bold">{otherUser.diaries.length}</p>
-                  <p className="text-xs">フォロワー</p>
-                </li>
-              </ul>
-
-              <div className="bg-primary rounded-lg text-white flex items-center justify-center py-1">
-                <span className="i-ri-user-follow-line w-5 h-5"></span>
-                <button>フォローする</button>
-              </div>
-            </div>
+          <UserInfo user={otherUser} isMypage={false}/>
 
             {/* ペット情報 */}
             <div className="flex flex-col gap-3 border border-main shadow-xl p-4 rounded-lg">

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -5,13 +5,11 @@ import { useRouteGuard } from "@/_hooks/useRouteGuard";
 import { useSupabaseSession } from "@/_hooks/useSupabaseSession";
 import { useParams } from "next/navigation";
 import { toast, Toaster } from "react-hot-toast";
-import Image, { StaticImageData } from "next/image";
+import { StaticImageData } from "next/image";
 import usePreviewImage from "@/_hooks/usePreviewImage";
-import no_registration from "@/public/dog_registration.png";
 import no_diary_img from "@/public/no_diary_img.png";
 import summaryThumbnail from "@/public/summaryThumbnail.png";
 import PageLoading from "@/app/_components/PageLoading";
-import { getAgeInMonths } from "@/app/utils/getAgeInMonths";
 import InfiniteScroll from 'react-infinite-scroller';
 import LoadingDiary from "@/app/diaries/_components/LoadingDiary";
 import PostUnit from "@/app/_components/PostUnit";
@@ -21,6 +19,7 @@ import { UserMyPage } from "@/_types/user";
 import { MypageDiaryLists } from "@/_types/diary";
 import { MypageSummaryLists } from "@/_types/summary";
 import { MypageBookmarkLists } from "@/_types/bookmark";
+import UserDogInfo from "./_components/UserDogInfo";
 
 const UserPage: React.FC = () => {
   useRouteGuard();
@@ -103,31 +102,7 @@ const UserPage: React.FC = () => {
         {otherUser ? (
           <>
           <UserInfo user={otherUser} isMypage={false}/>
-
-            {/* ペット情報 */}
-            <div className="flex flex-col gap-3 border border-main shadow-xl p-4 rounded-lg">
-              <h3 className="text-lg text-primary font-bold text-center">わんちゃん情報</h3>
-
-              <div className="flex justify-around">
-                <Image 
-                  className="w-20 h-20 rounded-full border border-primary ring-primary ring-offset-1 ring"
-                  src={dogImg ? dogImg : no_registration} 
-                  alt="profile_image" 
-                  width={120} 
-                  height={120}
-                  style={{objectFit: "cover"}}
-                  priority={true}
-                />
-
-                <div className="flex flex-col justify-around">
-                  <p className="text-xl font-bold text-center">{otherUser.dog.name}</p>
-                  <div className="flex gap-2">
-                    <p>{getAgeInMonths(otherUser.dog.birthDate)}</p>
-                    <p>{otherUser.dog.sex}</p>
-                  </div>
-                </div>
-              </div>
-            </div>
+          <UserDogInfo user={otherUser} dogImg={dogImg} />
 
             {/* タブの実装 */}
             <div>

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -80,7 +80,7 @@ const UserPage: React.FC = () => {
         setShowLists(otherUser.summaries);
         setDefaultImg(summaryThumbnail);
         setLinkPrefix("summaries")
-      } else if (selectedTab === "いいね") {
+      } else if (selectedTab === "お気に入り") {
         setShowLists(otherUser.bookmarks);
         setDefaultImg(no_diary_img);
         setLinkPrefix("favorites")


### PR DESCRIPTION
# what
Mypageとユーザー詳細ページのコンポーネントが類似の構成だったため。
コンポーネントに切り出して、再利用できるようにリファクタリングを実施。

# what
以下の実装を行いました。

- ユーザーの基本情報をまとめるコンポーネントを作成(UserInfo.tsx)
- ユーザーのペット情報をまとめるコンポーネントを作成(UserDogInfo.tsx)
- タブによってユーザーの投稿一覧やお気に入りの一覧を切り替えるコンポーネントを作成(TabNavigation.tsx)