### PR TITLE
お気に入り登録・削除機能の実装

### DIFF
--- a/src/_types/diary.ts
+++ b/src/_types/diary.ts
@@ -23,6 +23,7 @@ export interface BaseDiary {
 export interface DiaryDetails extends BaseDiary {
   owner: { id: string, nickname: string }
   comments: CommentProps[];
+  bookmarks: { id: string }[];
 }
 
 export interface MypageDiaryLists {

--- a/src/app/api/diaries/[id]/bookmarks/route.ts
+++ b/src/app/api/diaries/[id]/bookmarks/route.ts
@@ -3,7 +3,7 @@ import { userAuthentication } from "@/app/utils/userAuthentication";
 import prisma from "@/libs/prisma";
 import { NextRequest, NextResponse } from "next/server";
 
-// ブックマーク登録
+// お気に入り登録
 export const POST = async(request: NextRequest, { params } : { params : Promise<{ id: string }>}) => {
   const { id } = await params
   const { data, error } = await userAuthentication(request);
@@ -19,13 +19,13 @@ export const POST = async(request: NextRequest, { params } : { params : Promise<
       },
     });
 
-    return NextResponse.json({ status: "OK", message: "ブックマーク登録しました" }, { status: 200 });
+    return NextResponse.json({ status: "OK", message: "お気に入り登録しました" }, { status: 200 });
   } catch(error) {
     return handleError(error);
   }
 }; 
 
-// ブックマーク削除
+// お気に入り削除
 export const DELETE = async(request: NextRequest, { params } : { params : Promise<{ id: string }>}) => {
   const { id } = await params
   const { data, error } = await userAuthentication(request);
@@ -42,7 +42,7 @@ export const DELETE = async(request: NextRequest, { params } : { params : Promis
     });
 
     if(!deleteBookmark) {
-      return NextResponse.json({ status: "Not found.", message: "ブックマークデータが確認できませんでした"}, { status: 404});
+      return NextResponse.json({ status: "Not found.", message: "データの確認ができませんでした"}, { status: 404});
     }
 
     await prisma.bookMark.delete({
@@ -51,7 +51,7 @@ export const DELETE = async(request: NextRequest, { params } : { params : Promis
       },
     });
 
-    return NextResponse.json({ status: "OK", message: "ブックマークを解除しました"}, { status: 200 });
+    return NextResponse.json({ status: "OK", message: "お気に入りを解除しました"}, { status: 200 });
   } catch(error) {
     return handleError(error);
   }

--- a/src/app/api/diaries/[id]/route.ts
+++ b/src/app/api/diaries/[id]/route.ts
@@ -47,6 +47,7 @@ export const GET = async(request:NextRequest, { params } : { params: Promise<{id
         bookmarks: {
           select: {
             id: true,
+            ownerId: true,
           }
         }
       },

--- a/src/app/api/diaries/[id]/route.ts
+++ b/src/app/api/diaries/[id]/route.ts
@@ -43,6 +43,11 @@ export const GET = async(request:NextRequest, { params } : { params: Promise<{id
             id: true,
             nickname: true,
           }
+        },
+        bookmarks: {
+          select: {
+            id: true,
+          }
         }
       },
     });

--- a/src/app/api/mypage/route.ts
+++ b/src/app/api/mypage/route.ts
@@ -64,7 +64,11 @@ export const GET = async(request: NextRequest) => {
       return NextResponse.json({ status: "Not found" , message: "User information Not found."}, { status: 404});
     }
 
-    return NextResponse.json( { status: "OK", userInfo: userInfo }, { status: 200 });
+    const formattedUserInfo = {
+      ...userInfo,
+      bookmarks: userInfo.bookmarks.map((b) => b.diary),
+    }
+    return NextResponse.json( { status: "OK", userInfo: formattedUserInfo }, { status: 200 });
   } catch(error) {
     return handleError(error);
   }

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -62,7 +62,12 @@ export const GET = async(request: NextRequest, { params } : { params : Promise<{
       return NextResponse.json({ status: "Not found.", message: "User Not found"}, { status: 404});
     }
 
-    return NextResponse.json({ status: "OK", otherUser: otherUser }, { status: 200 });
+    const formattedUserInfo = {
+      ...otherUser,
+      bookmarks: otherUser.bookmarks.map((b) => b.diary),
+    }
+
+    return NextResponse.json({ status: "OK", otherUser: formattedUserInfo }, { status: 200 });
   } catch(error) {
     return handleError(error);
   }

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -91,6 +91,27 @@ const DiaryDetail: React.FC = () => {
       setIsDeleting(false);
     }
   }
+
+  const changeFavorite = async() => {
+    if (!token) return;
+
+    try {
+      const response = await fetch(`/api/diaries/${id}/bookmarks`, {
+        headers: {
+          "Content-Type" : "application/json",
+          Authorization: token,
+        },
+        method: "POST",
+      });
+
+      if(response.status === 200) {
+        toast.success("お気に入り登録しました");
+      }
+    } catch(error) {
+      console.log(error);
+      toast.error("お気に入り登録に失敗しました");
+    }
+  }
   
   useEffect(() => {
     if (!token) return;
@@ -183,13 +204,15 @@ const DiaryDetail: React.FC = () => {
                 <span className="i-mdi-chat-processing-outline"></span>
                 <span className="text-sm">コメントする</span>
               </button>
-              <button className="w-1/2 p-2 text-center border border-primary solid rounded flex items-center justify-center gap-1">
+              <button 
+                className="w-1/2 p-2 text-center border border-primary solid rounded flex items-center justify-center gap-1"
+                onClick={() => changeFavorite()}
+              >
                 <span className="i-material-symbols-bookmark-add-outline"></span>
-                <span className="text-sm">ブックマーク</span>
+                <span className="text-sm">お気に入り</span>
               </button>
             </div>
             
-            {/* コメント一覧表示 */}
             <div>
               <CommentList 
                 comments={diary.comments} 
@@ -200,7 +223,7 @@ const DiaryDetail: React.FC = () => {
               />
             </div>
           </div>
-          {/* モーダル表示エリア */}
+
           <ModalWindow show={openModal} onClose={ModalClose} >
             <>
               {modalType === "edit" && <DiaryForm diary={diary} isEdit={true} onClose={ModalClose} />}

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -133,7 +133,10 @@ const DiaryDetail: React.FC = () => {
 
         const { diary } = await res.json();
         setDiary(diary);
-        setIsBookmarked(diary.bookmarks && diary.bookmarks.length > 0);
+        // ログインユーザーに紐づいたbookmarkが1つでも存在すればtrue, なければfalseを返す。
+        const UserBookmarked = diary.bookmarks.some((b: {id: string, ownerId: string}) => b.ownerId === currentUserId);
+        setIsBookmarked(UserBookmarked);
+
       } catch(error) {
         console.log(error);
       } finally {
@@ -142,6 +145,7 @@ const DiaryDetail: React.FC = () => {
     }
     fetchDiary()
   }, [id, token, refresh]);
+
 
   return(
     <>

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -27,6 +27,7 @@ const DiaryDetail: React.FC = () => {
   const { token, session } = useSupabaseSession();
   const currentUserId = session?.user.id;
   const [diary, setDiary] = useState<DiaryDetails | null >(null);
+  const [isBookmarked, setIsBookmarked] = useState<boolean>(false);
   const thumbnailImage = usePreviewImage(diary?.imageKey ?? null, "diary_img")
   const [openModal, setOpenModal] = useState(false);
   const [refresh, setRefresh] = useState<boolean>(false);
@@ -101,11 +102,16 @@ const DiaryDetail: React.FC = () => {
           "Content-Type" : "application/json",
           Authorization: token,
         },
-        method: "POST",
+        method: isBookmarked ? "DELETE" : "POST",
       });
 
       if(response.status === 200) {
-        toast.success("お気に入り登録しました");
+        setIsBookmarked(!isBookmarked);
+        if(isBookmarked) {
+          toast.success("お気に入りの解除をしました");
+        } else {
+          toast.success("お気に入り登録をしました");
+        } 
       }
     } catch(error) {
       console.log(error);
@@ -127,6 +133,7 @@ const DiaryDetail: React.FC = () => {
 
         const { diary } = await res.json();
         setDiary(diary);
+        setIsBookmarked(diary.bookmarks && diary.bookmarks.length > 0);
       } catch(error) {
         console.log(error);
       } finally {
@@ -135,8 +142,6 @@ const DiaryDetail: React.FC = () => {
     }
     fetchDiary()
   }, [id, token, refresh]);
-
-  console.log(diary)
 
   return(
     <>
@@ -204,12 +209,19 @@ const DiaryDetail: React.FC = () => {
                 <span className="i-mdi-chat-processing-outline"></span>
                 <span className="text-sm">コメントする</span>
               </button>
+
               <button 
-                className="w-1/2 p-2 text-center border border-primary solid rounded flex items-center justify-center gap-1"
+                className={`w-1/2 p-2 text-center border border-primary solid rounded flex items-center justify-center gap-1 ${isBookmarked && "bg-primary text-white"}`}
                 onClick={() => changeFavorite()}
               >
-                <span className="i-material-symbols-bookmark-add-outline"></span>
-                <span className="text-sm">お気に入り</span>
+                <span className={isBookmarked 
+                ? `i-material-symbols-bookmark-remove-outline`
+                : `i-material-symbols-bookmark-add-outline`
+                }></span>
+
+                <span className="text-sm">
+                  {isBookmarked ? "お気に入り済" : "お気に入り登録" }
+                </span>
               </button>
             </div>
             

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -84,7 +84,6 @@ const MyPage: React.FC = () => {
     SelectLists();
   }, [currentUser, selectedTab]);
 
-
   return (
     <div className="flex justify-center text-gray-800">
       <div className="my-20 pb-20 px-4 w-full max-w-screen-lg flex flex-col gap-12 overflow-y-auto">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -73,7 +73,7 @@ const MyPage: React.FC = () => {
       } else if (selectedTab === "お気に入り") {
         setShowLists(currentUser.bookmarks);
         setDefaultImg(no_diary_img);
-        setLinkPrefix("favorites")
+        setLinkPrefix("diaries")
       }
     } catch (error) {
       console.log(error);

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -83,7 +83,7 @@ const UserPage: React.FC = () => {
       } else if (selectedTab === "お気に入り") {
         setShowLists(otherUser.bookmarks);
         setDefaultImg(no_diary_img);
-        setLinkPrefix("favorites")
+        setLinkPrefix("diaries")
       }
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
# why
ユーザーが日記のお気に入り登録/削除をできるようにするため。

# what
以下の実装をしました。
- 日記詳細ページの「お気に入り登録」ボタンをクリックするとお気に入り登録ができる。
- 日記詳細ページの「お気に入り解除」ボタンをクリックするとお気に入りの解除ができる。
- 登録したお気に入り一覧はMypageのお気に入りタブから確認ができる。