### PR TITLE
検索機能の実装

### DIFF
--- a/src/app/_components/SearchForm.tsx
+++ b/src/app/_components/SearchForm.tsx
@@ -1,17 +1,58 @@
-const SearchForm: React.FC = () => {
+import React from "react";
+import { useForm, SubmitHandler } from "react-hook-form";
+
+interface SearchValue {
+  keywords: string;
+}
+
+interface searchProps {
+  token: string | null;
+}
+
+const SearchForm: React.FC<searchProps> = (token) => {
+  const { register, handleSubmit, reset,} = useForm<SearchValue>();
+
+  const onSubmit: SubmitHandler<SearchValue> = async(data) => {
+    const searchWords = data.keywords.split(" ").filter(word => word.trim() !== "") ?? null
+
+    if(!token) return;
+    try {
+      const response = await fetch(`/api/diaries/search?keywords=${searchWords}`, {
+        headers: {
+          "Content-Type" : "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const { diaries } = await response.json();
+
+      reset();
+    } catch(error) {
+      console.log(error);
+    }
+  }
+
   return(
-    <form className="max-w-md my-6">   
-    <label id="default-search" className="mb-2 text-sm font-medium text-gray-900 sr-only">Search</label>
-    <div className="relative">
-      <div className="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
-        <svg className="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+    <form className="max-w-md my-6" onSubmit={handleSubmit(onSubmit)}>   
+      <label id="default-search" className="mb-2 text-sm font-medium text-gray-900 sr-only">Search</label>
+      <div className="relative">
+        <div className="absolute inset-y-0 start-0 flex items-center ps-4 pointer-events-none">
+          <svg className="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
             <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
-        </svg>
+          </svg>
+        </div>
+        <input 
+          type="search"
+          id="default-search"
+          className="block w-full p-4 ps-10 text-sm text-gray-900 border border-primary rounded-full bg-gray-50 focus:ring-primary focus:border-primary"
+          required
+          {...register("keywords")} 
+        />
+        <button 
+          type="submit"
+          className="text-white absolute end-2.5 bottom-2.5 bg-primary hover:bg-primary focus:ring-2 focus:outline-none font-medium rounded-full text-sm px-4 py-2">検索
+        </button>
       </div>
-      <input type="search" id="default-search" className="block w-full p-4 ps-10 text-sm text-gray-900 border border-primary rounded-full bg-gray-50 focus:ring-primary focus:border-primary" required />
-      <button type="submit" className="text-white absolute end-2.5 bottom-2.5 bg-primary hover:bg-primary focus:ring-4 focus:outline-none focus:ring-primary font-medium rounded-full text-sm px-4 py-2">検索</button>
-    </div>
-  </form>
+    </form>
   )
 }
 

--- a/src/app/_components/SearchForm.tsx
+++ b/src/app/_components/SearchForm.tsx
@@ -1,5 +1,7 @@
+import { DiaryDetails } from "@/_types/diary";
 import React from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
+import toast, { Toaster } from "react-hot-toast";
 
 interface SearchValue {
   keywords: string;
@@ -7,14 +9,15 @@ interface SearchValue {
 
 interface searchProps {
   token: string | null;
+  onSearchResults: (diaries: DiaryDetails[]) => void;
 }
 
-const SearchForm: React.FC<searchProps> = (token) => {
+const SearchForm: React.FC<searchProps> = ({ token, onSearchResults}) => {
   const { register, handleSubmit, reset,} = useForm<SearchValue>();
 
   const onSubmit: SubmitHandler<SearchValue> = async(data) => {
     const searchWords = data.keywords.split(" ").filter(word => word.trim() !== "") ?? null
-
+    
     if(!token) return;
     try {
       const response = await fetch(`/api/diaries/search?keywords=${searchWords}`, {
@@ -24,7 +27,12 @@ const SearchForm: React.FC<searchProps> = (token) => {
         },
       });
       const { diaries } = await response.json();
-
+      if(diaries.length > 0) {
+        toast.success(`${diaries.length}件ヒットしました`)
+        onSearchResults(diaries);
+      } else {
+        toast.error(`ヒットする日記がありませんでした`)
+      }
       reset();
     } catch(error) {
       console.log(error);
@@ -32,27 +40,30 @@ const SearchForm: React.FC<searchProps> = (token) => {
   }
 
   return(
-    <form className="max-w-md my-6" onSubmit={handleSubmit(onSubmit)}>   
-      <label id="default-search" className="mb-2 text-sm font-medium text-gray-900 sr-only">Search</label>
-      <div className="relative">
-        <div className="absolute inset-y-0 start-0 flex items-center ps-4 pointer-events-none">
-          <svg className="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-            <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
-          </svg>
+    <>
+      <form className="max-w-md my-6" onSubmit={handleSubmit(onSubmit)}>   
+        <label id="default-search" className="mb-2 text-sm font-medium text-gray-900 sr-only">Search</label>
+        <div className="relative">
+          <div className="absolute inset-y-0 start-0 flex items-center ps-4 pointer-events-none">
+            <svg className="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+              <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+            </svg>
+          </div>
+          <input 
+            type="search"
+            id="default-search"
+            className="block w-full p-4 ps-10 text-sm text-gray-900 border border-primary rounded-full bg-gray-50 focus:ring-primary focus:border-primary"
+            required
+            {...register("keywords")} 
+          />
+          <button 
+            type="submit"
+            className="text-white absolute end-2.5 bottom-2.5 bg-primary hover:bg-primary focus:ring-2 focus:outline-none font-medium rounded-full text-sm px-4 py-2">検索
+          </button>
         </div>
-        <input 
-          type="search"
-          id="default-search"
-          className="block w-full p-4 ps-10 text-sm text-gray-900 border border-primary rounded-full bg-gray-50 focus:ring-primary focus:border-primary"
-          required
-          {...register("keywords")} 
-        />
-        <button 
-          type="submit"
-          className="text-white absolute end-2.5 bottom-2.5 bg-primary hover:bg-primary focus:ring-2 focus:outline-none font-medium rounded-full text-sm px-4 py-2">検索
-        </button>
-      </div>
-    </form>
+      </form>
+      <Toaster />
+    </>
   )
 }
 

--- a/src/app/_components/SearchForm.tsx
+++ b/src/app/_components/SearchForm.tsx
@@ -1,4 +1,4 @@
-import { DiaryDetails } from "@/_types/diary";
+
 import React from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import toast, { Toaster } from "react-hot-toast";
@@ -7,12 +7,13 @@ interface SearchValue {
   keywords: string;
 }
 
-interface searchProps {
+interface SearchProps<T> {
   token: string | null;
-  onSearchResults: (diaries: DiaryDetails[]) => void;
+  onSearchResults: (results: T[]) => void;
+  searchType: "diaries" | "summaries";
 }
 
-const SearchForm: React.FC<searchProps> = ({ token, onSearchResults}) => {
+const SearchForm = <T,>({ token, onSearchResults, searchType }: SearchProps<T>) => {
   const { register, handleSubmit, reset,} = useForm<SearchValue>();
 
   const onSubmit: SubmitHandler<SearchValue> = async(data) => {
@@ -20,18 +21,19 @@ const SearchForm: React.FC<searchProps> = ({ token, onSearchResults}) => {
     
     if(!token) return;
     try {
-      const response = await fetch(`/api/diaries/search?keywords=${searchWords}`, {
+      const response = await fetch(`/api/${searchType}/search?keywords=${searchWords}`, {
         headers: {
           "Content-Type" : "application/json",
           Authorization: `Bearer ${token}`,
         },
       });
-      const { diaries } = await response.json();
-      if(diaries.length > 0) {
-        toast.success(`${diaries.length}件ヒットしました`)
-        onSearchResults(diaries);
+
+      const { lists } = await response.json();
+      if(lists.length > 0) {
+        toast.success(`${lists.length}件ヒットしました`)
+        onSearchResults(lists);
       } else {
-        toast.error(`ヒットする日記がありませんでした`)
+        toast.error("検索結果が見つかりませんでした")
       }
       reset();
     } catch(error) {

--- a/src/app/_components/SearchForm.tsx
+++ b/src/app/_components/SearchForm.tsx
@@ -46,7 +46,8 @@ const SearchForm = <T,>({ token, onSearchResults, searchType }: SearchProps<T>) 
   }, [token]);
 
   const handleChange = (text: string) => {
-    setText(text);
+    const normalizedText = text.replace(/　/g, " ");
+    setText(normalizedText);
     const keywords = text.split(" "); // 入力されたkeywordを半角スペースで分割
     const lastKeyword = keywords[keywords.length - 1]; // keywordsの配列の最後の要素を取得して変数化。
     if (lastKeyword.length > 0) {
@@ -106,6 +107,7 @@ const SearchForm = <T,>({ token, onSearchResults, searchType }: SearchProps<T>) 
             className="text-white absolute end-2.5 bottom-2.5 bg-primary hover:bg-primary focus:ring-2 focus:outline-none font-medium rounded-full text-sm px-4 py-2">検索
           </button>
         </div>
+        <div className="px-4 mt-2 shadow-lg bg-gray-50 rounded-lg">
         {isFocus && (
           suggestions?.map((suggestion, i) => (
             <p
@@ -116,11 +118,13 @@ const SearchForm = <T,>({ token, onSearchResults, searchType }: SearchProps<T>) 
                 setText(currentKeywords.join(" ")); // 入力値を再度スペース区切りの形式に変換
                 setIsFocus(false);
               }}
+              className="text-sm py-1"
             >
-              {suggestion.name}
+              # {suggestion.name}
             </p>
           ))
         )}
+        </div>
       </form>
       <Toaster />
     </>

--- a/src/app/_components/SearchForm.tsx
+++ b/src/app/_components/SearchForm.tsx
@@ -1,5 +1,6 @@
+"use client"
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import toast, { Toaster } from "react-hot-toast";
 
@@ -13,60 +14,116 @@ interface SearchProps<T> {
   searchType: "diaries" | "summaries";
 }
 
-const SearchForm = <T,>({ token, onSearchResults, searchType }: SearchProps<T>) => {
-  const { register, handleSubmit, reset,} = useForm<SearchValue>();
+interface KeyWordProps {
+  id: string;
+  name: string;
+}
 
-  const onSubmit: SubmitHandler<SearchValue> = async(data) => {
-    const searchWords = data.keywords.split(" ").filter(word => word.trim() !== "") ?? null
-    
-    if(!token) return;
+const SearchForm = <T,>({ token, onSearchResults, searchType }: SearchProps<T>) => {
+  const { register, handleSubmit, reset } = useForm<SearchValue>();
+  const [text, setText] = useState<string>("");
+  const [isFocus, setIsFocus] = useState<boolean>(false);
+  const [suggestions, setSuggestions] = useState<KeyWordProps[]>([]);
+  const [tagLists, setTagLists] = useState<KeyWordProps[]>([]);
+  
+  useEffect(() => {
+    const fetchLists = async() => {
+      if(!token) return;
+      try {
+        const res = await fetch("/api/tags/", {
+          headers: {
+            "Content-Type" : "application/json",
+            Authorization: token,
+          },
+        });
+        const { tags } = await res.json();
+        setTagLists(tags)
+      } catch(error) {
+        console.log(error)
+      }
+    }
+    fetchLists();
+  }, [token]);
+
+  const handleChange = (text: string) => {
+    setText(text);
+    const keywords = text.split(" "); // 入力されたkeywordを半角スペースで分割
+    const lastKeyword = keywords[keywords.length - 1]; // keywordsの配列の最後の要素を取得して変数化。
+    if (lastKeyword.length > 0) {
+      const KeywordsMatch = tagLists.filter((opt) => {
+        const regex = new RegExp(`${lastKeyword}`, "gi");
+        return opt.name.match(regex);
+      });
+      setSuggestions(KeywordsMatch) // キーワードマッチした候補が配列で格納される。
+    } 
+  }
+
+  const onSubmit: SubmitHandler<SearchValue> = async (data) => {
+    const searchWords = data.keywords.split(" ").filter(word => word.trim() !== "") ?? null;
+    if (!token) return;
     try {
       const response = await fetch(`/api/${searchType}/search?keywords=${searchWords}`, {
         headers: {
-          "Content-Type" : "application/json",
+          "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
       });
-
       const { lists } = await response.json();
-      if(lists.length > 0) {
+      if (lists.length > 0) {
         toast.success(`${lists.length}件ヒットしました`)
         onSearchResults(lists);
       } else {
         toast.error("検索結果が見つかりませんでした")
       }
       reset();
-    } catch(error) {
+    } catch (error) {
       console.log(error);
     }
   }
 
-  return(
+  return (
     <>
-      <form className="max-w-md my-6" onSubmit={handleSubmit(onSubmit)}>   
+      <form className="max-w-md my-6" onSubmit={handleSubmit(onSubmit)}>
         <label id="default-search" className="mb-2 text-sm font-medium text-gray-900 sr-only">Search</label>
         <div className="relative">
           <div className="absolute inset-y-0 start-0 flex items-center ps-4 pointer-events-none">
             <svg className="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-              <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+              <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z" />
             </svg>
           </div>
-          <input 
+          <input
             type="search"
             id="default-search"
+            value={text}
             className="block w-full p-4 ps-10 text-sm text-gray-900 border border-primary rounded-full bg-gray-50 focus:ring-primary focus:border-primary"
             required
-            {...register("keywords")} 
+            {...register("keywords")}
+            onFocus={() => setIsFocus(true)}
+            onChange={(e) => handleChange(e.target.value)}
           />
-          <button 
+          <button
             type="submit"
             className="text-white absolute end-2.5 bottom-2.5 bg-primary hover:bg-primary focus:ring-2 focus:outline-none font-medium rounded-full text-sm px-4 py-2">検索
           </button>
         </div>
+        {isFocus && (
+          suggestions?.map((suggestion, i) => (
+            <p
+              key={i}
+              onClick={() => {
+                const currentKeywords = text.split(" ");
+                currentKeywords[currentKeywords.length - 1] = suggestion.name; // text(フォーム入力されている配列)の末尾のデータを候補のtextにする
+                setText(currentKeywords.join(" ")); // 入力値を再度スペース区切りの形式に変換
+                setIsFocus(false);
+              }}
+            >
+              {suggestion.name}
+            </p>
+          ))
+        )}
       </form>
       <Toaster />
     </>
   )
 }
-
 export default SearchForm;

--- a/src/app/api/diaries/search/route.ts
+++ b/src/app/api/diaries/search/route.ts
@@ -13,17 +13,31 @@ export const GET = async(request: NextRequest) => {
   try {
     const diaries = await prisma.diary.findMany({
       where: {
-        OR: keywords.map(keyword => ({
-          diaryTags: {
-            some: {
-              tag: {
-                name: {
-                  contains: keyword
+        OR: [
+          ...keywords.map(keyword => ({
+            diaryTags: {
+              some: {
+                tag: {
+                  name: {
+                    contains: keyword
+                  },
                 },
               },
             },
-          },
-        })),
+          })),
+          ...keywords.map(keyword => ({
+            title: {
+              contains: keyword,
+              mode: 'insensitive' as const, // modeの型に合わせるようにinsensitive型であることを明示。
+            }
+          })),
+          ...keywords.map(keyword => ({
+            content: {
+              contains: keyword,
+              mode: 'insensitive' as const,
+            }
+          })),
+        ]
       },
       include: {
         diaryTags: {

--- a/src/app/api/diaries/search/route.ts
+++ b/src/app/api/diaries/search/route.ts
@@ -48,7 +48,7 @@ export const GET = async(request: NextRequest) => {
       },
     });
 
-    return NextResponse.json({ status: "OK", diaries: diaries }, { status: 200});
+    return NextResponse.json({ status: "OK", lists: diaries }, { status: 200});
   } catch(error) {
     return handleError(error);
   }

--- a/src/app/api/summaries/search/route.ts
+++ b/src/app/api/summaries/search/route.ts
@@ -13,17 +13,31 @@ export const GET = async(request: NextRequest) => {
   try {
     const summaries = await prisma.summary.findMany({
       where: {
-        OR: keywords.map(keyword => ({
-          summaryTags: {
-            some: {
-              tag: {
-                name: {
-                  contains: keyword
+        OR: [
+          ...keywords.map(keyword => ({
+            summaryTags: {
+              some: {
+                tag: {
+                  name: {
+                    contains: keyword
+                  },
                 },
               },
             },
-          },
-        })),
+          })),
+          ...keywords.map(keyword => ({
+            title: {
+              contains: keyword,
+              mode: 'insensitive' as const,
+            }
+          })),
+          ...keywords.map(keyword => ({
+            explanation: {
+              contains: keyword,
+              mode: 'insensitive' as const,
+            }
+          })),
+        ]
       },
       include: {
         summaryTags: {
@@ -34,7 +48,7 @@ export const GET = async(request: NextRequest) => {
       },
     });
     
-    return NextResponse.json({ status: "OK", summaries: summaries }, { status: 200 });
+    return NextResponse.json({ status: "OK", lists: summaries }, { status: 200 });
   } catch(error) {
     return handleError(error);
   }

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { userAuthentication } from "@/app/utils/userAuthentication";
+import { handleError } from "@/app/utils/errorHandler";
+import prisma from "@/libs/prisma";
+
+export const GET = async (request: NextRequest) => {
+  const { error } = await userAuthentication(request);
+  if (error) return handleError(error);
+
+  try {
+    const tags = await prisma.tag.findMany({
+      select: {
+        id: true,
+        name: true,
+      }
+    })
+    return NextResponse.json({ status: "OK", tags: tags }, { status: 200 });
+  } catch(error) {
+    return handleError(error);
+  }
+}

--- a/src/app/diaries/page.tsx
+++ b/src/app/diaries/page.tsx
@@ -73,7 +73,7 @@ const DiaryIndex: React.FC = () => {
     <div className="flex justify-center">
       <div className="my-20 pb-10 px-4 relative w-full max-w-screen-lg">
         <Tab />
-        <SearchForm token={token} onSearchResults={handleSearchResults}/>
+        <SearchForm token={token} onSearchResults={handleSearchResults} searchType="diaries" />
         <InfiniteScroll 
           loadMore={fetchDiary}
           hasMore={hasMore}

--- a/src/app/diaries/page.tsx
+++ b/src/app/diaries/page.tsx
@@ -63,12 +63,17 @@ const DiaryIndex: React.FC = () => {
     fetchDiary();
   }, []);
 
+  const handleSearchResults = (diaries: DiaryDetails[]) => {
+    setDiaryList(diaries);
+    setPage(0);
+    setHasMore(false);
+  }
 
   return(
     <div className="flex justify-center">
       <div className="my-20 pb-10 px-4 relative w-full max-w-screen-lg">
         <Tab />
-        <SearchForm token={token} />
+        <SearchForm token={token} onSearchResults={handleSearchResults}/>
         <InfiniteScroll 
           loadMore={fetchDiary}
           hasMore={hasMore}

--- a/src/app/diaries/page.tsx
+++ b/src/app/diaries/page.tsx
@@ -68,7 +68,7 @@ const DiaryIndex: React.FC = () => {
     <div className="flex justify-center">
       <div className="my-20 pb-10 px-4 relative w-full max-w-screen-lg">
         <Tab />
-        <SearchForm />
+        <SearchForm token={token} />
         <InfiniteScroll 
           loadMore={fetchDiary}
           hasMore={hasMore}

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -40,7 +40,6 @@ const SummaryDetail: React.FC = () => {
         });
 
         const { summary } = await res.json();
-        console.log(summary)
         setSummary(summary);
       } catch(error) {
         console.log(error);

--- a/src/app/summaries/page.tsx
+++ b/src/app/summaries/page.tsx
@@ -62,12 +62,18 @@ const SummaryIndex: React.FC = () => {
   useEffect(() => {
     fetchSummary();
   },[]);
+
+  const handleSearchResults = (summaries: AllSummary[]) => {
+    setSummaryList(summaries);
+    setPage(0);
+    setHasMore(false);
+  }
  
   return(
     <div className="flex justify-center">
       <div className="my-20 pb-10 px-4 relative w-full max-w-screen-lg">
         <Tab />
-        <SearchForm />
+        <SearchForm token={token} onSearchResults={handleSearchResults} searchType="summaries"/>
         <InfiniteScroll
           loadMore={fetchSummary}
           hasMore={hasMore}


### PR DESCRIPTION
# why
ユーザーがキーワードで日記やまとめを検索できるようにするため。

# what
以下の実装をしました。
- 日記一覧ページで検索フォームにキーワードを入力して、検索をクリックすると「タイトル」「本文」「タグ」のいずれかにキーワードが含まれる日記が表示される。
- まとめ一覧ページで検索フォームにキーワードを入力して、検索をクリックすると「タイトル」「本文」「タグ」のいずれかにキーワードが含まれるまとめが表示される。
- 日記一覧/まとめ一覧ページの検索ウィンドウでキーワードを入力すると、サジェストが表示される。
- キーワードに合致する日記/まとめがあればpopupで件数が表示される。もし検索結果がなければ、「検索結果はありませんでした」の表示がされる。
