### PR TITLE
修正_トップページのUI

### DIFF
--- a/src/app/_components/Chart.tsx
+++ b/src/app/_components/Chart.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from "react";
 import { WeightInfo } from "@/_types/weight";
-import { LineChart, XAxis, YAxis, Tooltip,  CartesianGrid, Line } from "recharts";
+import { LineChart, XAxis, YAxis, Tooltip,  CartesianGrid, Line, ResponsiveContainer } from "recharts";
 import { filterLastWeek, filterLastMonth, filterLastThreeMonths } from "../utils/filterWeightData";
 
 
@@ -39,11 +39,14 @@ const Chart: React.FC<ChartProps> = ({ dogWeight }) => {
 
   // クリックごとに表示する日付を切り替える
   const intervalValue = () => {
+    const dataLength = filteredDate.length;
     switch(period) {
       case 'month':
-        return 7;
+        // 最大7個程度日付表示されるように指定
+        return Math.max(0,Math.floor(dataLength / 7)); 
       case '3month':
-        return 30;
+        // 最大10個程度日付表示されるように指定
+        return Math.max(0, Math.floor(dataLength / 10));
       default:
         return 0; 
     }
@@ -52,22 +55,27 @@ const Chart: React.FC<ChartProps> = ({ dogWeight }) => {
 
   return(
     <>
-      <LineChart width={256} height={200} data={filteredDate}
-        margin={{ top:10, right:20, left:-40, bottom: 0}}>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart 
+          data={filteredDate}
+          margin={{ top:10, right:20, left:-40, bottom: 0}}
+        >
           <XAxis dataKey="careDate" interval={intervalValue()} tick={{fontSize:10}} angle={-30}/>
           <YAxis dataKey="amount" />
           <CartesianGrid strokeDasharray="3 3" />
           <Tooltip />
           <Line type="monotone" dataKey="amount" strokeWidth={3} stroke="#15A083" fill="#15A083" />
-      </LineChart>
+        </LineChart>
+      </ResponsiveContainer>
+      
       <ul className="flex justify-center">
-        <li className="w-1/3 border rounded-lg text-main bg-primary p-1 text-center">
+        <li className={`w-1/3 border border-primary rounded-lg p-1 text-center ${period === 'week' ? 'bg-primary text-main' : 'bg-main text-primary'}`}>
           <button onClick={ () => setPeriod('week')}>1週間</button>
         </li>
-        <li className="w-1/3 border rounded-lg bg-primary text-main p-1 text-center">
+        <li className={`w-1/3 border border-primary rounded-lg p-1 text-center ${period === 'month' ? 'bg-primary text-main' : 'bg-main text-primary'}`}>
           <button onClick={ () => setPeriod('month')}>1ヶ月</button>
         </li>
-        <li className="w-1/3 border rounded-lg bg-primary text-main p-1 text-center">
+        <li className={`w-1/3 border border-primary rounded-lg p-1 text-center ${period === '3month' ? 'bg-primary text-main ' : 'bg-main text-primary'}`}>
           <button onClick={ () => setPeriod('3month')}>3ヶ月</button>
         </li>
       </ul>

--- a/src/app/_components/Chart.tsx
+++ b/src/app/_components/Chart.tsx
@@ -46,18 +46,22 @@ const Chart: React.FC<ChartProps> = ({ dogWeight }) => {
 
   return(
     <>
-      <ResponsiveContainer width="100%" height={300}>
-        <LineChart 
-          data={filteredDate}
-          margin={{ top:10, right:20, left:-40, bottom: 0}}
-        >
-          <XAxis dataKey="careDate" interval={intervalValue()} tick={{fontSize:10}} angle={-30}/>
-          <YAxis dataKey="amount" />
-          <CartesianGrid strokeDasharray="3 3" />
-          <Tooltip />
-          <Line type="monotone" dataKey="amount" strokeWidth={3} stroke="#15A083" fill="#15A083" />
-        </LineChart>
-      </ResponsiveContainer>
+      {filteredDate.length > 0 ? (
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart 
+            data={filteredDate}
+            margin={{ top:10, right:20, left:-40, bottom: 0}}
+          >
+            <XAxis dataKey="careDate" interval={intervalValue()} tick={{fontSize:10}} angle={-30}/>
+            <YAxis dataKey="amount" />
+            <CartesianGrid strokeDasharray="3 3" />
+            <Tooltip />
+            <Line type="monotone" dataKey="amount" strokeWidth={3} stroke="#15A083" fill="#15A083" dot={{r: 3}}/>
+          </LineChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="text-center mb-4">記録がありません</div>
+      )}
       
       <ul className="flex justify-center">
         <li className={`w-1/3 border border-primary rounded-lg p-1 text-center ${period === 'week' ? 'bg-primary text-main' : 'bg-main text-primary'}`}>

--- a/src/app/_components/Chart.tsx
+++ b/src/app/_components/Chart.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import { WeightInfo } from "@/_types/weight";
 import { LineChart, XAxis, YAxis, Tooltip,  CartesianGrid, Line, ResponsiveContainer } from "recharts";
 import { filterLastWeek, filterLastMonth, filterLastThreeMonths } from "../utils/filterWeightData";
-
+import { changeFromISOtoDate } from "../utils/ChangeDateTime/changeFromISOtoDate";
 
 interface ChartProps {
   dogWeight: WeightInfo[]
@@ -24,17 +24,9 @@ const Chart: React.FC<ChartProps> = ({ dogWeight }) => {
     }
   }
 
-  // 日付をmm/dd形式に変換
-  const careDateFormat = (date: string) => {
-    const changeDate = new Date(date);
-    const month = (`0${changeDate.getMonth() + 1}`).slice(-2);
-    const day = (`0${changeDate.getDate()}`).slice(-2);
-    return `${month}/${day}`
-  }
-
   const filteredDate = getFilterData().map(d => ({
     ...d,
-    careDate: careDateFormat(d.careDate),
+    careDate: changeFromISOtoDate(d.careDate, "MonthDate"),
   }));
 
   // クリックごとに表示する日付を切り替える
@@ -51,7 +43,6 @@ const Chart: React.FC<ChartProps> = ({ dogWeight }) => {
         return 0; 
     }
   }
-
 
   return(
     <>

--- a/src/app/_components/Chart.tsx
+++ b/src/app/_components/Chart.tsx
@@ -26,7 +26,7 @@ const Chart: React.FC<ChartProps> = ({ dogWeight }) => {
 
   const filteredDate = getFilterData().map(d => ({
     ...d,
-    careDate: changeFromISOtoDate(d.careDate, "MonthDate"),
+    careDate: changeFromISOtoDate(d.careDate, "monthDate"),
   }));
 
   // クリックごとに表示する日付を切り替える

--- a/src/app/_components/Menu.tsx
+++ b/src/app/_components/Menu.tsx
@@ -21,7 +21,7 @@ const Menu: React.FC = () => {
   if (!showMenu) return null;
 
   return(
-    <div className="fixed z-50 w-full h-16 max-w-md -translate-x-1/2 bg-main border border-gray-200 rounded-full bottom-0.5 left-1/2 shadow-md">
+    <div className="fixed z-50 w-full h-16 max-w-md -translate-x-1/2 bg-main border-main rounded-full bottom-0.5 left-1/2 shadow-2xl">
         <ul className="grid h-full max-w-md grid-cols-5 mx-auto">
           {menuList.map((menu) => {
             return(

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -96,7 +96,7 @@ const Home: React.FC = () => {
               </div>
             </div>
 
-            <div className="font-medium text-gray-800 flex justify-between py-2 px-4 border rounded-lg shadow-md">
+            <div className="font-medium text-gray-800 flex justify-between py-2 px-4 border-main rounded-lg shadow-md">
               <div className="flex flex-col gap-1 text-sm text-gray-800">
                 <div className="flex items-center gap-2">
                   <span className="i-material-symbols-sound-detection-dog-barking-outline w-5 h-5"></span>

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 import  Chart from "../_components/Chart"
 import IconButton from "../_components/IconButton";
 import  PageLoading  from "@/app/_components/PageLoading";
-import { changeDateFormat } from "../utils/ChangeDateTime/changeDateFormat";
+import { changeFromISOtoDate } from "../utils/ChangeDateTime/changeFromISOtoDate";
 import { changeTimeFormat } from "../utils/ChangeDateTime/changeTimeFormat";
 import { WeightInfo } from "@/_types/weight";
 import { TodayCareInfo } from "@/_types/care";
@@ -104,11 +104,11 @@ const Home: React.FC = () => {
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="i-mdi-cake w-5 h-5"></span>
-                  <span className="text-base">{changeDateFormat(dogInfo.dog.birthDate)}</span>
+                  <span className="text-base">{changeFromISOtoDate(dogInfo.dog.birthDate, "date")}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="i-mdi-home w-5 h-5"></span>
-                  <span className="text-base">{changeDateFormat(dogInfo.dog.adoptionDate)}</span>
+                  <span className="text-base">{changeFromISOtoDate(dogInfo.dog.adoptionDate, "date")}</span>
                 </div>
               </div>
 

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -73,12 +73,12 @@ const Home: React.FC = () => {
 
   return(
     <div className="flex justify-center text-gray-800">
-      <div className="w-full my-20 pb-20 px-4 flex flex-col gap-10 overflow-y: auto">
+      <div className="w-full my-20 pb-20 px-8 flex flex-col gap-10 overflow-y: auto">
         {/* 犬の情報 */}
       {(dogInfo && dogImage) ? (
         <>
           <div className="flex flex-col gap-6">
-            <div className="flex justify-between">
+            <div className="flex justify-around">
               <div>
                 <Image 
                   className="w-28 h-28 rounded-full border border-primary ring-primary ring-offset-2 ring"

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -126,14 +126,15 @@ const Home: React.FC = () => {
 
           {/* 予定のエリア */}
           <div>
-            <h2 className="text-primary font-bold text-2xl mb-4">今日の予定</h2>
+            <h2 className="text-primary font-bold text-2xl mb-4">今日の記録/予定</h2>
             <ul className="flex flex-col gap-1">
               {todayCare.length === 0 ? (
                 <p>今日の予定はありません</p>
               ) : (
                 todayCare.map((care) => {
                   return(
-                    <li key={care.id} className="border rounded-full py-2 px-4 shadow-md">
+                    <li key={care.id} 
+                        className="bg-main border-2 border-primary text-primary rounded-full py-2 px-4">
                       <div className="flex gap-2">
                         <span className={`${care.careList.icon} w-5 h-5`}></span>
                         <span className="w-24">{care.careList.name}</span>

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -11,7 +11,6 @@ import  Chart from "../_components/Chart"
 import IconButton from "../_components/IconButton";
 import  PageLoading  from "@/app/_components/PageLoading";
 import { changeFromISOtoDate } from "../utils/ChangeDateTime/changeFromISOtoDate";
-import { changeTimeFormat } from "../utils/ChangeDateTime/changeTimeFormat";
 import { WeightInfo } from "@/_types/weight";
 import { TodayCareInfo } from "@/_types/care";
 import { DogProfile } from "@/_types/dog";
@@ -138,7 +137,7 @@ const Home: React.FC = () => {
                       <div className="flex gap-2">
                         <span className={`${care.careList.icon} w-5 h-5`}></span>
                         <span className="w-24">{care.careList.name}</span>
-                        <span>{changeTimeFormat(care.careDate)}</span>
+                        <span>{changeFromISOtoDate(care.careDate, "time")}</span>
                       </div>
                     </li>
                   )

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -73,7 +73,7 @@ const Home: React.FC = () => {
 
   return(
     <div className="flex justify-center text-gray-800">
-      <div className="w-64 my-20 pb-20 flex flex-col gap-10 overflow-y: auto">
+      <div className="w-full my-20 pb-20 px-4 flex flex-col gap-10 overflow-y: auto">
         {/* 犬の情報 */}
       {(dogInfo && dogImage) ? (
         <>
@@ -87,7 +87,7 @@ const Home: React.FC = () => {
                   width={112} 
                   height={112}
                   style={{objectFit: "cover"}}
-                  priority={true}
+                  priority
                 />
               </div>
               <div className="flex flex-col justify-center">

--- a/src/app/utils/ChangeDateTime/changeDateFormat.ts
+++ b/src/app/utils/ChangeDateTime/changeDateFormat.ts
@@ -1,1 +1,0 @@
-export const changeDateFormat = (date: string) => new Date(date).toLocaleDateString("ja-JP");

--- a/src/app/utils/ChangeDateTime/changeFromISOtoDate.ts
+++ b/src/app/utils/ChangeDateTime/changeFromISOtoDate.ts
@@ -12,9 +12,9 @@ export const changeFromISOtoDate = (date: string, changeFormat: string) => {
     formattedDate = format(zonedDate, 'yyyy/MM/dd HH:mm');
   } else if (changeFormat === "date") {
     formattedDate = format(zonedDate, 'yyyy-MM-dd');
-  } else if (changeFormat === "monthDate"){
+  } else if (changeFormat === "monthDate") {
     formattedDate = format(zonedDate, 'MM/dd');
-  } else {
+  } else if (changeFormat === "time") {
     formattedDate = format(zonedDate, 'HH:mm');
   }
 

--- a/src/app/utils/ChangeDateTime/changeFromISOtoDate.ts
+++ b/src/app/utils/ChangeDateTime/changeFromISOtoDate.ts
@@ -12,7 +12,7 @@ export const changeFromISOtoDate = (date: string, changeFormat: string) => {
     formattedDate = format(zonedDate, 'yyyy/MM/dd HH:mm');
   } else if (changeFormat === "date") {
     formattedDate = format(zonedDate, 'yyyy-MM-dd');
-  } else if (changeFormat === "MonthDate"){
+  } else if (changeFormat === "monthDate"){
     formattedDate = format(zonedDate, 'MM/dd');
   } else {
     formattedDate = format(zonedDate, 'HH:mm');

--- a/src/app/utils/ChangeDateTime/changeFromISOtoDate.ts
+++ b/src/app/utils/ChangeDateTime/changeFromISOtoDate.ts
@@ -12,6 +12,8 @@ export const changeFromISOtoDate = (date: string, changeFormat: string) => {
     formattedDate = format(zonedDate, 'yyyy/MM/dd HH:mm');
   } else if (changeFormat === "date") {
     formattedDate = format(zonedDate, 'yyyy-MM-dd');
+  } else if (changeFormat === "MonthDate"){
+    formattedDate = format(zonedDate, 'MM/dd');
   } else {
     formattedDate = format(zonedDate, 'HH:mm');
   }

--- a/src/app/utils/ChangeDateTime/changeTimeFormat.ts
+++ b/src/app/utils/ChangeDateTime/changeTimeFormat.ts
@@ -1,4 +1,0 @@
-export const changeTimeFormat = (date: string) => { 
-  const timePart = date.slice(11, 16); 
-  return timePart;
-};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -39,9 +39,6 @@ const config: Config = {
       width: {
         'main': '450px',
       },
-      backgroundImage : {
-        "first-view" : "url('/first_view.png')"
-      },
       screens: {
         xs: "450px",
       },


### PR DESCRIPTION
# why
・トップページのUI崩れの修正をするため。

# what
以下の実装を行いました。
・Chartのグラフ表示の修正。1日しか体重記録が登録されていない場合でもドットが入るように実装。
・日付の表示をリファクタリング。
・MenuバーのUI修正。
・本日の予定/記録が予定時刻順に並ぶようにバックエンドの修正。