### PR TITLE
修正_未ログイン時のリダイレクト先設定

### DIFF
--- a/src/app/cares/[id]/page.tsx
+++ b/src/app/cares/[id]/page.tsx
@@ -15,8 +15,10 @@ import { toast, Toaster } from "react-hot-toast"
 import DeleteAlert from "@/app/_components/DeleteAlert";
 import deleteStorageImage from "@/app/utils/deleteStorageImage";
 import { CareDetails } from "@/_types/care";
+import { useRouteGuard } from "@/_hooks/useRouteGuard";
 
 const CareDetail: React.FC = () => {
+  useRouteGuard();
   const params = useParams();
   const { id } = params;
   const { token, session } = useSupabaseSession();

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -19,8 +19,10 @@ import DeleteRoundButton from "@/app/_components/DeleteRoundButton";
 import CommentForm from "../_components/CommentForm";
 import CommentList from "../_components/CommentList";
 import Link from "next/link";
+import { useRouteGuard } from "@/_hooks/useRouteGuard";
 
 const DiaryDetail: React.FC = () => {
+  useRouteGuard();
   const params = useParams();
   const router = useRouter();
   const { id } = params;

--- a/src/app/diaries/page.tsx
+++ b/src/app/diaries/page.tsx
@@ -7,12 +7,14 @@ import LoadingDiary from "./_components/LoadingDiary";
 import { DiaryDetails } from "@/_types/diary";
 import ModalWindow from "../_components/ModalWindow";
 import DiaryForm from "./_components/DiaryForm";
+import { useRouteGuard } from "@/_hooks/useRouteGuard";
 import  Tab  from "@/app/_components/Tab";
 import  SearchForm  from "@/app/_components/SearchForm";
 import PostUnit from "../_components/PostUnit";
 import no_diary_img from "/public/no_diary_img.png";
 
 const DiaryIndex: React.FC = () => {
+  useRouteGuard();
   const { token } = useSupabaseSession();
   const [diaryList, setDiaryList] = useState<DiaryDetails[]>([]);
   const [hasMore, setHasMore] = useState(true);

--- a/src/app/summaries/[id]/page.tsx
+++ b/src/app/summaries/[id]/page.tsx
@@ -13,8 +13,10 @@ import ModalWindow from "@/app/_components/ModalWindow";
 import SummaryForm from "../_components/SummaryForm";
 import DeleteAlert from "@/app/_components/DeleteAlert";
 import { toast, Toaster } from "react-hot-toast"
+import { useRouteGuard } from "@/_hooks/useRouteGuard";
 
 const SummaryDetail: React.FC = () => {
+  useRouteGuard();
   const params = useParams();
   const router = useRouter();
   const { id } = params;

--- a/src/app/summaries/page.tsx
+++ b/src/app/summaries/page.tsx
@@ -11,8 +11,10 @@ import LoadingDiary from "../diaries/_components/LoadingDiary";
 import { AllSummary } from "@/_types/summary";
 import PostUnit from "../_components/PostUnit";
 import summaryThumbnail from "/public/summaryThumbnail.png";
+import { useRouteGuard } from "@/_hooks/useRouteGuard";
 
 const SummaryIndex: React.FC = () => {
+  useRouteGuard();
   const { token } = useSupabaseSession();
   const [summaryList, setSummaryList] = useState<AllSummary[]>([]);
   const [hasMore, setHasMore] = useState(true);

--- a/src/app/users/[id]/_components/TabNavigation.tsx
+++ b/src/app/users/[id]/_components/TabNavigation.tsx
@@ -21,7 +21,6 @@ interface showListsProps {
 }
 
 const TabNavigation: React.FC<showListsProps> = ({ user, showLists, defaultImg, selectTab, SelectLists, linkPrefix, selectedTab }) => {
-  console.log(selectedTab)
   return(
     <>
       <div>


### PR DESCRIPTION
# Why
未ログイン時に日記やまとめの一覧ページ、詳細ページに遷移できる状態のため。

# what
以下のページに未ログイン状態ではアクセスした場合は、ログインページにリダイレクトするように修正しました。
- 日記一覧
- 日記詳細
- まとめ一覧
- まとめ詳細
- お世話詳細
